### PR TITLE
fix: OAuth signup timeout and URL parameter issues

### DIFF
--- a/apps/dashboard/src/components/auth/SignupFormContainer.tsx
+++ b/apps/dashboard/src/components/auth/SignupFormContainer.tsx
@@ -27,7 +27,8 @@ interface SignupFormContainerProps {
 
 export const SignupFormContainer: React.FC<SignupFormContainerProps> = ({ accountType }) => {
   const [searchParams] = useSearchParams();
-  const isOAuthCompletion = searchParams.get('complete') === 'true';
+  // Check sessionStorage for OAuth completion (NO URL parameters per CLAUDE.md)
+  const isOAuthCompletion = typeof window !== 'undefined' && sessionStorage.getItem('oauth_signup_complete') === 'true';
 
   const [state, setState] = useState<SignupState>({
     isLoading: false,
@@ -185,6 +186,13 @@ export const SignupFormContainer: React.FC<SignupFormContainerProps> = ({ accoun
             // Profile creation succeeded - show success immediately
             console.log('✅ OAuth profile completion succeeded');
 
+            // Clear OAuth sessionStorage after successful completion
+            sessionStorage.removeItem('oauth_signup_complete');
+            sessionStorage.removeItem('oauth_user_id');
+            sessionStorage.removeItem('oauth_user_email');
+            sessionStorage.removeItem('oauth_user_account_type');
+            console.log('🧹 Cleared OAuth completion sessionStorage');
+
             toast({
               title: "Profile Created!",
               description: "Welcome to KStoryBridge! Your buyer profile has been set up.",
@@ -272,6 +280,13 @@ export const SignupFormContainer: React.FC<SignupFormContainerProps> = ({ accoun
 
             // Profile creation succeeded - show success immediately
             console.log('✅ Creator OAuth profile completion succeeded');
+
+            // Clear OAuth sessionStorage after successful completion
+            sessionStorage.removeItem('oauth_signup_complete');
+            sessionStorage.removeItem('oauth_user_id');
+            sessionStorage.removeItem('oauth_user_email');
+            sessionStorage.removeItem('oauth_user_account_type');
+            console.log('🧹 Cleared OAuth completion sessionStorage');
 
             toast({
               title: "Profile Created!",

--- a/apps/dashboard/src/components/auth/signupService.ts
+++ b/apps/dashboard/src/components/auth/signupService.ts
@@ -111,7 +111,7 @@ export const completeOAuthProfile = async (
         });
 
         const timeoutPromise = new Promise<{ error: Error }>((_, reject) =>
-          setTimeout(() => reject(new Error('Metadata update timeout after 5 seconds')), 5000)
+          setTimeout(() => reject(new Error('Metadata update timeout after 15 seconds')), 15000)
         );
 
         const { error: metadataError } = await Promise.race([metadataUpdatePromise, timeoutPromise]);
@@ -218,7 +218,7 @@ export const completeOAuthProfile = async (
         });
 
         const timeoutPromise = new Promise<{ error: Error }>((_, reject) =>
-          setTimeout(() => reject(new Error('Metadata update timeout after 5 seconds')), 5000)
+          setTimeout(() => reject(new Error('Metadata update timeout after 15 seconds')), 15000)
         );
 
         const { error: metadataError } = await Promise.race([metadataUpdatePromise, timeoutPromise]);

--- a/apps/dashboard/src/pages/AuthCallbackSimple.tsx
+++ b/apps/dashboard/src/pages/AuthCallbackSimple.tsx
@@ -141,21 +141,26 @@ const AuthCallbackSimple = () => {
           final: finalFlow
         });
 
-        // 4. Clear sessionStorage
+        // 4. Clear initial OAuth sessionStorage (will be replaced with completion data if signup)
         if (typeof window !== 'undefined') {
           sessionStorage.removeItem('oauth_account_type');
           sessionStorage.removeItem('oauth_flow');
-          console.log('🧹 Cleared OAuth session storage');
+          console.log('🧹 Cleared initial OAuth session storage');
         }
 
         // 5. Redirect based on flow type
 
         if (finalFlow === 'signup') {
           // OAuth signup - redirect to complete profile
+          // Store completion data in sessionStorage (NO URL parameters per CLAUDE.md)
+          sessionStorage.setItem('oauth_signup_complete', 'true');
+          sessionStorage.setItem('oauth_user_id', user.id);
+          sessionStorage.setItem('oauth_user_email', user.email);
+          sessionStorage.setItem('oauth_user_account_type', finalAccountType);
+
           const signupPath = getSignupPath(finalAccountType);
-          const signupUrl = `${signupPath}?complete=true&user_id=${user.id}&email=${encodeURIComponent(user.email)}`;
-          console.log('📝 OAuth signup - redirecting to:', signupUrl);
-          navigate(signupUrl);
+          console.log('📝 OAuth signup - redirecting to:', signupPath);
+          navigate(signupPath);
         } else {
           // OAuth signin - redirect to dashboard immediately (no profile check here)
           // Profile check will happen on dashboard load to avoid infinite getSession() loops


### PR DESCRIPTION
## Summary
Fixes critical OAuth signup issues in production:
- ✅ Metadata update timeout (5s → 15s for production latency)
- ✅ Removed URL parameters from OAuth redirects (per CLAUDE.md rule)
- ✅ Use sessionStorage for OAuth completion data
- ✅ Clean up sessionStorage after successful profile creation

## Root Cause
1. **Metadata Update Timeout**: `supabase.auth.updateUser()` was timing out after 5 seconds in production, causing signup to abort even though profile was created successfully
2. **URL Parameters Violation**: OAuth callback was redirecting to `/signup/buyer?complete=true&user_id=X&email=Y`, violating CLAUDE.md rule: "never ever use parameter in oauth callback URL"

## Changes

### `apps/dashboard/src/components/auth/signupService.ts`
- Increased metadata update timeout from 5 seconds to 15 seconds (lines 114 & 221)
- Applies to both buyer and creator OAuth flows

### `apps/dashboard/src/pages/AuthCallbackSimple.tsx`
- Removed URL parameters from signup completion redirect
- Store OAuth data in sessionStorage instead:
  - `oauth_signup_complete: 'true'`
  - `oauth_user_id: <user.id>`
  - `oauth_user_email: <user.email>`
  - `oauth_user_account_type: <buyer|creator>`

### `apps/dashboard/src/components/auth/SignupFormContainer.tsx`
- Changed OAuth completion detection from URL params → sessionStorage
- Added sessionStorage cleanup after successful profile creation (both buyer & creator)

## Test Plan
- [ ] Test Google OAuth signup on staging (dashboard-staging-*.vercel.app)
- [ ] Verify no URL parameters in redirect URLs
- [ ] Confirm sessionStorage is cleared after completion
- [ ] Test production OAuth signup (15s timeout should be sufficient)

## Deployment
- ✅ Committed to `v2` branch
- ✅ Deployed to staging environment
- ⏳ Awaiting approval for production merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)