### PR TITLE
fix: Fix OAuth signin profile bypass (clean)

### DIFF
--- a/apps/dashboard/src/components/RootRedirect.tsx
+++ b/apps/dashboard/src/components/RootRedirect.tsx
@@ -16,74 +16,9 @@ export function RootRedirect() {
 
       console.log('🏠 RootRedirect: Determining account type for user:', user.email);
 
-      // Check for pending OAuth signin (needs profile verification)
-      const isPendingOAuth = sessionStorage.getItem('oauth_signin_pending');
-
-      if (isPendingOAuth === 'true') {
-        console.log('🔍 RootRedirect: OAuth signin detected - verifying profile existence');
-
-        const oauthAccountType = sessionStorage.getItem('oauth_signin_account_type');
-        const oauthUserId = sessionStorage.getItem('oauth_signin_user_id');
-        const oauthEmail = sessionStorage.getItem('oauth_signin_email');
-
-        // Clear OAuth flags immediately to prevent re-checking
-        sessionStorage.removeItem('oauth_signin_pending');
-        sessionStorage.removeItem('oauth_signin_account_type');
-        sessionStorage.removeItem('oauth_signin_user_id');
-        sessionStorage.removeItem('oauth_signin_email');
-
-        if (oauthAccountType && oauthUserId) {
-          try {
-            // Check if profile exists in database
-            let profileExists = false;
-
-            if (oauthAccountType === 'buyer') {
-              const { data } = await supabase
-                .from('user_buyers')
-                .select('id')
-                .eq('id', oauthUserId)
-                .maybeSingle();
-              profileExists = !!data;
-            } else if (oauthAccountType === 'creator') {
-              const { data } = await supabase
-                .from('user_creators')
-                .select('id')
-                .eq('id', oauthUserId)
-                .maybeSingle();
-              profileExists = !!data;
-            }
-
-            if (!profileExists) {
-              // No profile found - redirect to signup
-              console.log('❌ RootRedirect: OAuth user has no profile - redirecting to signup');
-              toast({
-                title: "Account Not Found",
-                description: "Your account doesn't exist. Please sign up first.",
-                variant: "destructive"
-              });
-              setTimeout(() => {
-                navigate(`/signup/${oauthAccountType}`, { replace: true });
-              }, 2000);
-              return;
-            }
-
-            console.log('✅ RootRedirect: OAuth profile verified - continuing to dashboard');
-            // Profile exists - fall through to normal redirect logic below
-          } catch (error) {
-            console.error('❌ RootRedirect: Error checking OAuth profile:', error);
-            // On error, redirect to signup to be safe
-            toast({
-              title: "Verification Error",
-              description: "Unable to verify your account. Please sign up.",
-              variant: "destructive"
-            });
-            setTimeout(() => {
-              navigate(`/signup/${oauthAccountType}`, { replace: true });
-            }, 2000);
-            return;
-          }
-        }
-      }
+      // NOTE: OAuth signin profile check removed - now handled in AuthCallbackSimple.tsx
+      // This eliminates race conditions and ensures profile is verified before user reaches dashboard
+      // Keeping this file for non-OAuth users who visit root URL directly
 
       try {
         // First check user metadata

--- a/apps/dashboard/src/components/auth/signupService.ts
+++ b/apps/dashboard/src/components/auth/signupService.ts
@@ -111,22 +111,33 @@ export const completeOAuthProfile = async (
         return { success: false, error: profileResult.error };
       }
 
-      // ✅ Profile creation succeeded - OAuth signup complete
+      // ✅ Profile creation succeeded - write metadata in non-blocking mode
       //
-      // Note: Metadata update intentionally skipped for OAuth flows
+      // STRATEGY: Attempt to write account_type metadata immediately but don't fail signup if it times out
       //
-      // REASON: Database tables (user_buyers) are the source of truth for account_type.
-      // RootRedirect.tsx has fallback logic (lines 101-192) that:
-      //   1. Checks database table for account_type if metadata missing
-      //   2. Lazily writes metadata after detecting from database
-      //   3. All subsequent loads use metadata (fast path)
+      // REASONING:
+      // - Writing metadata NOW gives fast path for subsequent loads (metadata check is instant)
+      // - If write times out, RootRedirect.tsx has fallback logic to write it lazily
+      // - Best of both worlds: performance optimization + reliability fallback
       //
-      // Blocking on metadata.updateUser() causes false timeout issues in production
-      // (similar to exchangeCodeForSession timeout already fixed in AuthCallbackSimple.tsx).
-      //
-      // TESTING: OAuth callback handler already uses this pattern successfully.
-      //
-      console.log('✅ OAuth buyer profile created - proceeding to dashboard (metadata will be written lazily by RootRedirect)');
+      console.log('🔄 Writing account_type metadata (non-blocking)');
+
+      // Non-blocking metadata update - don't await, don't fail signup on error
+      supabase.auth.updateUser({
+        data: { account_type: 'buyer' }
+      }).then(({ error }) => {
+        if (error) {
+          console.warn('⚠️ Metadata update failed (non-blocking):', error.message);
+          console.log('ℹ️ RootRedirect will write metadata lazily on next load');
+        } else {
+          console.log('✅ Account type metadata written successfully');
+        }
+      }).catch((error) => {
+        console.warn('⚠️ Metadata update exception (non-blocking):', error);
+        console.log('ℹ️ RootRedirect will write metadata lazily on next load');
+      });
+
+      console.log('✅ OAuth buyer profile created - proceeding to dashboard');
       const userResult = { success: true, user };
 
       // Send welcome email and Slack notification in background (non-blocking)
@@ -211,22 +222,33 @@ export const completeOAuthProfile = async (
         return { success: false, error: profileResult.error };
       }
 
-      // ✅ Profile creation succeeded - OAuth signup complete
+      // ✅ Profile creation succeeded - write metadata in non-blocking mode
       //
-      // Note: Metadata update intentionally skipped for OAuth flows
+      // STRATEGY: Attempt to write account_type metadata immediately but don't fail signup if it times out
       //
-      // REASON: Database tables (user_creators) are the source of truth for account_type.
-      // RootRedirect.tsx has fallback logic (lines 101-192) that:
-      //   1. Checks database table for account_type if metadata missing
-      //   2. Lazily writes metadata after detecting from database
-      //   3. All subsequent loads use metadata (fast path)
+      // REASONING:
+      // - Writing metadata NOW gives fast path for subsequent loads (metadata check is instant)
+      // - If write times out, RootRedirect.tsx has fallback logic to write it lazily
+      // - Best of both worlds: performance optimization + reliability fallback
       //
-      // Blocking on metadata.updateUser() causes false timeout issues in production
-      // (similar to exchangeCodeForSession timeout already fixed in AuthCallbackSimple.tsx).
-      //
-      // TESTING: OAuth callback handler already uses this pattern successfully.
-      //
-      console.log('✅ OAuth creator profile created - proceeding to dashboard (metadata will be written lazily by RootRedirect)');
+      console.log('🔄 Writing account_type metadata (non-blocking)');
+
+      // Non-blocking metadata update - don't await, don't fail signup on error
+      supabase.auth.updateUser({
+        data: { account_type: 'creator' }
+      }).then(({ error }) => {
+        if (error) {
+          console.warn('⚠️ Metadata update failed (non-blocking):', error.message);
+          console.log('ℹ️ RootRedirect will write metadata lazily on next load');
+        } else {
+          console.log('✅ Account type metadata written successfully');
+        }
+      }).catch((error) => {
+        console.warn('⚠️ Metadata update exception (non-blocking):', error);
+        console.log('ℹ️ RootRedirect will write metadata lazily on next load');
+      });
+
+      console.log('✅ OAuth creator profile created - proceeding to dashboard');
       const userResult = { success: true, user };
 
       // Send welcome email and Slack notification in background (non-blocking)

--- a/apps/dashboard/src/pages/AuthCallbackSimple.tsx
+++ b/apps/dashboard/src/pages/AuthCallbackSimple.tsx
@@ -162,21 +162,102 @@ const AuthCallbackSimple = () => {
           console.log('📝 OAuth signup - redirecting to:', signupPath);
           navigate(signupPath);
         } else {
-          // OAuth signin - redirect to dashboard immediately (no profile check here)
-          // Profile check will happen on dashboard load to avoid infinite getSession() loops
-          console.log('✅ OAuth signin - setting up dashboard redirect with profile check');
+          // OAuth signin - VERIFY PROFILE EXISTS BEFORE REDIRECTING
+          // This prevents authenticated users without profiles from reaching dashboard
+          console.log('✅ OAuth signin - verifying profile existence before redirect');
 
-          // Store OAuth signin state for dashboard to verify profile existence
-          sessionStorage.setItem('oauth_signin_pending', 'true');
-          sessionStorage.setItem('oauth_signin_account_type', finalAccountType);
-          sessionStorage.setItem('oauth_signin_user_id', user.id);
-          sessionStorage.setItem('oauth_signin_email', user.email);
+          try {
+            // Check if profile exists in database
+            let profileExists = false;
+            let profileCheckError: string | null = null;
 
-          const dashboardPath = getDashboardPath(finalAccountType);
-          console.log('🔄 Redirecting to dashboard:', dashboardPath);
+            if (finalAccountType === 'buyer') {
+              const { data, error } = await withRetry(
+                () => supabase
+                  .from('user_buyers')
+                  .select('id')
+                  .eq('id', user.id)
+                  .maybeSingle(),
+                { maxRetries: 2, delay: 500 }
+              );
 
-          // Navigate to dashboard - profile check will happen there
-          navigate(dashboardPath);
+              if (error) {
+                console.error('❌ OAuth signin: Error checking buyer profile:', error);
+                profileCheckError = error.message;
+              } else {
+                profileExists = !!data;
+                console.log(profileExists ? '✅ Buyer profile found' : '❌ No buyer profile found');
+              }
+            } else if (finalAccountType === 'creator') {
+              const { data, error } = await withRetry(
+                () => supabase
+                  .from('user_creators')
+                  .select('id')
+                  .eq('id', user.id)
+                  .maybeSingle(),
+                { maxRetries: 2, delay: 500 }
+              );
+
+              if (error) {
+                console.error('❌ OAuth signin: Error checking creator profile:', error);
+                profileCheckError = error.message;
+              } else {
+                profileExists = !!data;
+                console.log(profileExists ? '✅ Creator profile found' : '❌ No creator profile found');
+              }
+            }
+
+            if (profileCheckError) {
+              // Database error - show error and redirect to signin
+              console.error('❌ OAuth signin: Profile check failed with database error');
+              toast({
+                title: "Connection Error",
+                description: "Unable to verify your profile. Please try signing in again.",
+                variant: "destructive"
+              });
+              navigate('/signin?error=profile_check_error');
+              return;
+            }
+
+            if (!profileExists) {
+              // No profile found - this is first-time OAuth "signin" (should be signup)
+              // Redirect to signup to complete profile
+              console.log('❌ OAuth signin: No profile found - redirecting to signup');
+
+              toast({
+                title: "Welcome!",
+                description: "Please complete your profile to get started.",
+                variant: "default"
+              });
+
+              // Set signup completion flags (reuse signup flow)
+              sessionStorage.setItem('oauth_signup_complete', 'true');
+              sessionStorage.setItem('oauth_user_id', user.id);
+              sessionStorage.setItem('oauth_user_email', user.email);
+              sessionStorage.setItem('oauth_user_account_type', finalAccountType);
+
+              const signupPath = getSignupPath(finalAccountType);
+              console.log('📝 Redirecting to signup:', signupPath);
+              navigate(signupPath);
+              return;
+            }
+
+            // Profile exists - proceed to dashboard
+            console.log('✅ OAuth signin: Profile verified - proceeding to dashboard');
+
+            const dashboardPath = getDashboardPath(finalAccountType);
+            console.log('🔄 Redirecting to dashboard:', dashboardPath);
+            navigate(dashboardPath);
+
+          } catch (error) {
+            console.error('❌ OAuth signin: Unexpected error during profile check:', error);
+            toast({
+              title: "Authentication Error",
+              description: "Unable to verify your profile. Please try signing in again.",
+              variant: "destructive"
+            });
+            navigate('/signin?error=profile_check_exception');
+          }
         }
 
       } catch (error) {


### PR DESCRIPTION
## Summary
**CRITICAL BUG FIXED**: OAuth signin bypassed profile existence check, allowing authenticated users without database profiles to reach dashboard.

This is a clean PR with only the OAuth fix, excluding dashboard-v2 changes.

## Changes

### File: `apps/dashboard/src/pages/AuthCallbackSimple.tsx`
- Added profile existence check for OAuth signin flow (lines 165-260)
- If no profile → redirect to signup
- If profile exists → proceed to dashboard

### File: `apps/dashboard/src/components/RootRedirect.tsx`
- Removed OAuth signin profile check logic (eliminates race condition)

### File: `apps/dashboard/src/components/auth/signupService.ts`
- Added non-blocking metadata updates (performance optimization)

## Impact
✅ OAuth signin with no profile → Redirects to signup (FIXED)
✅ OAuth signin with profile → Direct dashboard access
✅ OAuth signup → Profile created + metadata written
✅ Email auth flows → Unaffected

**Net Code Change**: +144 lines added, -106 lines removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)