### PR TITLE
Deploy website creator access popup to production

### DIFF
--- a/apps/website/src/pages/SigninPage.tsx
+++ b/apps/website/src/pages/SigninPage.tsx
@@ -1,9 +1,11 @@
+import { useState } from 'react';
 import UniversalHeader from '../components/UniversalHeader';
 import { Button } from '@kstorybridge/ui';
 import { Card, CardContent } from '../components/ui/card';
 import Footer from '../components/Footer';
 import { ArrowRight, Palette, ShoppingCart } from 'lucide-react';
 import { getDashboardUrl, getCreatorUrl } from '../config/urls';
+import CreatorComingSoonDialog from '../components/CreatorComingSoonDialog';
 
 /**
  * SIGNIN PAGE - Authentication Entry Point
@@ -16,6 +18,9 @@ import { getDashboardUrl, getCreatorUrl } from '../config/urls';
  */
 
 const SigninPage = () => {
+  // State for "Coming Soon" dialog
+  const [showComingSoon, setShowComingSoon] = useState(false);
+
   // Get environment-aware URLs
   const dashboardUrl = getDashboardUrl();
   const creatorUrl = getCreatorUrl();
@@ -61,23 +66,24 @@ const SigninPage = () => {
                   </p>
 
                   {/* Sign Up Button (Primary) */}
-                  <a href={`${creatorUrl}/signup`} className="block mb-4">
+                  <div className="block mb-4">
                     <Button
+                      onClick={() => setShowComingSoon(true)}
                       size="lg"
                       className="w-full bg-sunrise-coral hover:bg-sunrise-coral-600 text-white px-8 py-4 sm:py-6 text-base sm:text-lg rounded-full font-medium shadow-lg hover:shadow-xl transition-all duration-300"
                     >
                       Sign Up as Creator
                     </Button>
-                  </a>
+                  </div>
 
                   {/* Sign In Link */}
-                  <a
-                    href={`${creatorUrl}/signin`}
-                    className="flex items-center justify-center text-black hover:text-gray-700 transition-colors text-sm"
+                  <button
+                    onClick={() => setShowComingSoon(true)}
+                    className="w-full flex items-center justify-center text-black hover:text-gray-700 transition-colors text-sm"
                   >
                     Already have an account? Sign In
                     <ArrowRight className="w-4 h-4 ml-1" />
-                  </a>
+                  </button>
                 </CardContent>
               </Card>
 
@@ -137,6 +143,12 @@ const SigninPage = () => {
 
       {/* Footer */}
       <Footer />
+
+      {/* Creator Coming Soon Dialog */}
+      <CreatorComingSoonDialog
+        open={showComingSoon}
+        onOpenChange={setShowComingSoon}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
Add "Creator Access Coming Soon" popup to website signin page

## Changes
- Replace creator signup/signin links with popup triggers on `/signin`
- Show "Creator Access Coming Soon" dialog matching `/creators` page pattern
- Center "Already have an account? Sign In" button in creator section
- Buyer signup/signin links unchanged (still redirect to dashboard)

## User Experience
When users click creator signup or signin on the website signin page, they now see a clear "Coming Soon" message instead of being redirected to incomplete auth flows.

## Testing
✅ Tested on staging
- Popup appears correctly on creator button clicks
- "Got it" button closes popup
- Buyer links still work normally
- Button properly centered

## Deployment Target
Production: kstorybridge.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)