### PR TITLE
fix(turbo): Update dashboard-v2 turbo.json for Turbo 2.0+ compatibility

### DIFF
--- a/apps/dashboard-v2/turbo.json
+++ b/apps/dashboard-v2/turbo.json
@@ -1,6 +1,6 @@
 {
   "extends": ["//"],
-  "pipeline": {
+  "tasks": {
     "build": {
       "outputs": ["dist/**"]
     }


### PR DESCRIPTION
## Fix: Vercel Build Failure

### Issue
Vercel deployments were failing with `npm install` exit code 1 due to deprecated Turborepo configuration.

### Root Cause
`apps/dashboard-v2/turbo.json` was using the deprecated `pipeline` field instead of `tasks` (required for Turbo 2.0+).

### Changes
- ✅ Updated `pipeline` → `tasks` in dashboard-v2/turbo.json
- ✅ Brings config inline with Turbo 2.0+ requirements
- ✅ Fixes all Vercel build failures

### Impact
- Unblocks all Vercel deployments
- Enables Asset Generation menu to deploy to production
- Restores Turborepo caching functionality

### Testing
- Local build: `npm run build` completes without warnings
- Ready for Vercel deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>