### PR TITLE
Hide pricing link from website header

### DIFF
--- a/apps/website/src/components/UniversalHeader.tsx
+++ b/apps/website/src/components/UniversalHeader.tsx
@@ -74,6 +74,7 @@ const UniversalHeader = () => {
             >
               ABOUT
             </button>
+            {/* Pricing link hidden per requirements
             <button
               onClick={() => navigate('/creators/pricing')}
               className={`font-medium transition-colors ${
@@ -84,6 +85,7 @@ const UniversalHeader = () => {
             >
               PRICING
             </button>
+            */}
 
             {/* Auth Buttons */}
             <Button
@@ -167,6 +169,7 @@ const UniversalHeader = () => {
               >
                 ABOUT
               </button>
+              {/* Pricing link hidden per requirements
               <button
                 onClick={() => {
                   navigate('/creators/pricing');
@@ -180,6 +183,7 @@ const UniversalHeader = () => {
               >
                 PRICING
               </button>
+              */}
             </div>
 
             {/* Auth Buttons - Full width on mobile */}


### PR DESCRIPTION
## Summary
Hide the PRICING navigation link from the website header (both desktop and mobile).

## Changes

### Website App
- **UniversalHeader Component**
  - Commented out PRICING link from desktop navigation
  - Commented out PRICING link from mobile menu
  - Navigation now shows: CREATORS, BUYERS, NEWS, ABOUT, GET STARTED
  
## Behavior
- Pricing link is hidden from header navigation
- Pricing page (`/creators/pricing`) is still accessible via direct URL if needed
- No functional changes to other navigation items

## Files Changed
- **1 file** modified
- **4 insertions** (comment blocks)

## Testing Checklist
- [ ] Desktop header displays correctly without pricing link
- [ ] Mobile menu displays correctly without pricing link
- [ ] All other navigation links work properly
- [ ] GET STARTED button works correctly
- [ ] Pricing page is still accessible via direct URL `/creators/pricing`

## Deployment Notes
- This will trigger **selective deployment** via turbo-ignore
- Only Website app will rebuild
- Expected deployment time: ~2-3 minutes
- No database migrations required
- No breaking changes

## Rollback Plan
If issues arise, revert via GitHub:
```bash
git revert 19d6d922
git push origin main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)