### PR TITLE
Fix selective build: Stop dashboard from deploying on website-only changes

### DIFF
--- a/scripts/vercel-ignore-turbo.sh
+++ b/scripts/vercel-ignore-turbo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Vercel Selective Build Script for Turborepo Monorepo
-# Enhanced wrapper around turbo-ignore with debugging and auto-detection
+# Enhanced wrapper around turbo-ignore with explicit workspace detection
 #
 # Usage: cd ../.. && bash scripts/vercel-ignore-turbo.sh
 # Exit codes:
@@ -10,6 +10,16 @@
 # Enable debugging output
 set -x
 
+# Store the original directory (Vercel starts in apps/[app-name]/)
+ORIGINAL_DIR=$(pwd)
+APP_NAME=$(basename "$ORIGINAL_DIR")
+
+echo "Detected app directory: $APP_NAME"
+echo "Original directory: $ORIGINAL_DIR"
+
+# Navigate to monorepo root
+cd ../..
+
 # Verify we're in monorepo root
 if [ ! -f "turbo.json" ]; then
   echo "Error: turbo.json not found - not in monorepo root"
@@ -17,18 +27,40 @@ if [ ! -f "turbo.json" ]; then
   exit 1
 fi
 
-# Run turbo-ignore (auto-detects workspace from package.json)
-echo "Running turbo-ignore with auto-detection..."
-npx turbo-ignore
+# Map directory name to workspace package name
+case "$APP_NAME" in
+  "dashboard")
+    WORKSPACE="@kstorybridge/dashboard"
+    ;;
+  "dashboard-next")
+    WORKSPACE="@kstorybridge/dashboard-next"
+    ;;
+  "creator")
+    WORKSPACE="@kstorybridge/creator"
+    ;;
+  "website")
+    WORKSPACE="@kstorybridge/website"
+    ;;
+  *)
+    echo "Error: Unknown app directory: $APP_NAME"
+    echo "Cannot determine workspace name"
+    echo "Proceeding with build as fallback"
+    exit 1
+    ;;
+esac
+
+# Run turbo-ignore with explicit workspace name
+echo "Running turbo-ignore for workspace: $WORKSPACE"
+npx turbo-ignore "$WORKSPACE"
 
 # Capture exit code
 EXIT_CODE=$?
 
 # Debug output
 if [ $EXIT_CODE -eq 0 ]; then
-  echo "✓ No changes detected - skipping build"
+  echo "✓ No changes detected in $WORKSPACE - skipping build"
 else
-  echo "✓ Changes detected - proceeding with build"
+  echo "✓ Changes detected in $WORKSPACE - proceeding with build"
 fi
 
 exit $EXIT_CODE


### PR DESCRIPTION
## Summary
Fixes critical issue where **dashboard app deploys even when only website app changes**, wasting build time and causing unnecessary deployments.

## Problem
Vercel's selective build was **completely broken** due to turbo-ignore auto-detection failure:

```
≫ Inferred "kstorybridge-monorepo" as workspace from "package.json"
x No package found with name 'kstorybridge-monorepo' in workspace
✓ Proceeding with deployment  ❌ WRONG - should skip!
```

**Result**: All apps rebuild on every commit, defeating the purpose of selective deployment.

## Root Cause
The script runs `npx turbo-ignore` without arguments, causing it to:
1. Read root `package.json` → finds `"name": "kstorybridge-monorepo"`
2. Try to filter by "kstorybridge-monorepo" (which is NOT a workspace package)
3. Fail with "No package found" error
4. Default to **building everything** as fallback

## Solution
Modified `/scripts/vercel-ignore-turbo.sh` to:
1. Capture original app directory before `cd` to root
2. Map directory name to workspace package name:
   - `dashboard` → `@kstorybridge/dashboard`
   - `website` → `@kstorybridge/website`
   - `creator` → `@kstorybridge/creator`
   - `dashboard-next` → `@kstorybridge/dashboard-next`
3. Pass workspace name explicitly: `npx turbo-ignore "$WORKSPACE"`

## Changes

### Modified Files
- **scripts/vercel-ignore-turbo.sh** - Added explicit workspace detection

### New Behavior
**Before (Broken)**:
```bash
npx turbo-ignore  # Auto-detects wrong workspace → Fails → Builds everything
```

**After (Fixed)**:
```bash
npx turbo-ignore @kstorybridge/website  # Explicit workspace → Works correctly
```

## Expected Behavior After Deployment

### Scenario 1: Website-only changes
- ✅ **Dashboard**: turbo-ignore detects no changes → Exit 0 → **Skip build**
- ✅ **Website**: turbo-ignore detects changes → Exit 1 → **Build**
- ✅ **Creator**: turbo-ignore detects no changes → Exit 0 → **Skip build**

### Scenario 2: Dashboard-only changes
- ✅ **Dashboard**: turbo-ignore detects changes → Exit 1 → **Build**
- ✅ **Website**: turbo-ignore detects no changes → Exit 0 → **Skip build**
- ✅ **Creator**: turbo-ignore detects no changes → Exit 0 → **Skip build**

## Testing
Tested locally from both app directories:
```bash
# From dashboard
cd apps/dashboard && bash ../../scripts/vercel-ignore-turbo.sh
# Output: ≫ Using "@kstorybridge/dashboard" as workspace from arguments ✅

# From website
cd apps/website && bash ../../scripts/vercel-ignore-turbo.sh
# Output: ≫ Using "@kstorybridge/website" as workspace from arguments ✅
```

## Impact
- **Reduces unnecessary builds** - Only changed apps rebuild
- **Faster deployments** - Skip building 2-3 apps on most commits
- **Lower costs** - Fewer build minutes consumed
- **Vercel logs cleaner** - No more "No package found" errors

## Files Changed
- **1 file** modified
- **38 insertions**, **6 deletions**

## Deployment Notes
- This fixes the **Vercel Ignored Build Step** logic for all 6 projects
- No code changes to apps themselves
- No database migrations required
- Should see immediate effect on next deployment

## Verification
After merge, verify by:
1. Merging this PR to main
2. Making a website-only change on v2
3. Pushing to v2 → Should NOT trigger dashboard/creator deployment
4. Check Vercel logs for "No changes detected - skipping build"

🤖 Generated with [Claude Code](https://claude.com/claude-code)