### PR TITLE
fix(dashboard): Critical OAuth session timeout and database query fixes

### DIFF
--- a/apps/dashboard/src/components/auth/signupService.ts
+++ b/apps/dashboard/src/components/auth/signupService.ts
@@ -59,6 +59,15 @@ export const completeOAuthProfile = async (
   try {
     console.log('🔄 Completing OAuth buyer profile for:', user.email);
 
+    // Validate session before proceeding to prevent edge function calls with invalid sessions
+    if (!session?.access_token) {
+      console.error('❌ No valid session for OAuth profile creation');
+      return {
+        success: false,
+        error: 'Session expired. Please sign in again to complete your profile.'
+      };
+    }
+
     const buyerData = formData;
 
     // Use secure edge function for OAuth profile creation with retry for race conditions

--- a/apps/dashboard/src/hooks/useTierAccess.ts
+++ b/apps/dashboard/src/hooks/useTierAccess.ts
@@ -135,10 +135,11 @@ export const useTierAccess = (options?: UseTierAccessOptions): TierAccess => {
         }
 
         // Optimized query with specific field selection and timeout handling
+        // CRITICAL: Query by email (not id) per CLAUDE.md documentation to avoid RLS issues
         const queryPromise = supabase
           .from('user_buyers')
           .select('tier, id, email')  // Include additional fields for debugging
-          .eq('id', user.id)
+          .eq('email', user.email?.toLowerCase())
           .single();
 
         // Add timeout for tier lookup to prevent hanging

--- a/apps/dashboard/src/integrations/supabase/client.ts
+++ b/apps/dashboard/src/integrations/supabase/client.ts
@@ -545,7 +545,12 @@ supabase.auth.getSession = async () => {
   const isRecentOAuthFlow = () => {
     if (typeof window === 'undefined') return false;
     try {
+      // Check both oauth_completed_at (old) and oauth_signup_complete (new) for compatibility
       const lastOAuthTime = sessionStorage.getItem('oauth_completed_at');
+      const signupComplete = sessionStorage.getItem('oauth_signup_complete');
+
+      if (signupComplete === 'true') return true; // Immediate return if signup is active
+
       if (!lastOAuthTime) return false;
       const timeSinceOAuth = Date.now() - parseInt(lastOAuthTime);
       return timeSinceOAuth < 30000; // 30 seconds window

--- a/scripts/check-user-buyer.js
+++ b/scripts/check-user-buyer.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+/**
+ * Check if user_buyers record exists for a specific user
+ * Usage: node check-user-buyer.js [email or user_id]
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Load environment variables from dashboard app
+dotenv.config({ path: join(__dirname, '../apps/dashboard/.env.local') });
+dotenv.config({ path: join(__dirname, '../apps/dashboard/.env') });
+
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = process.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.error('❌ Missing Supabase credentials');
+  console.error('Required: VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+async function checkUserBuyer(identifier) {
+  console.log(`\n🔍 Checking user_buyers record for: ${identifier}\n`);
+
+  // Try both email and ID queries
+  const queries = [
+    { field: 'email', value: identifier },
+    { field: 'id', value: identifier }
+  ];
+
+  for (const { field, value } of queries) {
+    console.log(`📊 Querying by ${field}...`);
+
+    const { data, error } = await supabase
+      .from('user_buyers')
+      .select('*')
+      .eq(field, value)
+      .maybeSingle();
+
+    if (error) {
+      console.error(`❌ Error querying by ${field}:`, error.message);
+      continue;
+    }
+
+    if (data) {
+      console.log(`✅ Found record (via ${field}):\n`);
+      console.log(JSON.stringify(data, null, 2));
+      return data;
+    } else {
+      console.log(`⚠️  No record found by ${field}`);
+    }
+  }
+
+  console.log('\n❌ User not found in user_buyers table\n');
+  console.log('💡 Note: Cannot check auth.users table with anon key (requires service role key)\n');
+
+  return null;
+}
+
+// Get identifier from command line or use default test user
+const identifier = process.argv[2] || 'sungho@kstorybridge.com';
+
+checkUserBuyer(identifier)
+  .then(() => process.exit(0))
+  .catch(err => {
+    console.error('❌ Script error:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Critical Production Bug Fixes

Fixes OAuth authentication failures in production dashboard app.

### Issues Fixed

1. **Session Timeout on OAuth Completion** (Primary Issue)
   - OAuth redirect to `/signup/buyer` wasn't detected as OAuth flow
   - Used 10-second timeout instead of 90 seconds
   - **Result**: `getSession timeout after 10 seconds` errors in production

2. **Query-By-Email Violation** (Critical)
   - `useTierAccess` hook queried by `id` instead of `email`
   - Violated CLAUDE.md documentation requirements
   - **Result**: 406 "Not Acceptable" errors on tier queries

3. **Missing Session Validation**
   - No validation before OAuth edge function calls
   - **Result**: Edge function called with invalid/expired sessions

4. **Database Verification**
   - Added diagnostic script to verify user records
   - Confirmed root cause: User records not being created despite "success" response

### Changes

**Modified Files:**
- `apps/dashboard/src/integrations/supabase/client.ts` - Extended timeout detection
- `apps/dashboard/src/hooks/useTierAccess.ts` - Fixed query pattern
- `apps/dashboard/src/components/auth/signupService.ts` - Added session validation
- `scripts/check-user-buyer.js` - Added diagnostic tool

### Technical Details

**Session Timeout Fix:**
```typescript
// Now checks both oauth_completed_at AND oauth_signup_complete
const signupComplete = sessionStorage.getItem('oauth_signup_complete');
if (signupComplete === 'true') return true;
```

**Query Fix:**
```typescript
// Changed from:
.eq('id', user.id)

// To:
.eq('email', user.email?.toLowerCase())
```

### Testing Plan

After deployment, monitor for:
- ✅ No "getSession timeout" errors
- ✅ No 406 errors on tier queries  
- ✅ OAuth profile creation succeeds
- ✅ User records exist in database after signup

### Deployment

This PR will trigger auto-deploy to production for the dashboard app only (via turbo-ignore).

**Commit**: 4e4a7fa3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>