### PR TITLE
fix: Move vector search to edge function for production

### DIFF
--- a/apps/dashboard/src/services/vectorSearchService.ts
+++ b/apps/dashboard/src/services/vectorSearchService.ts
@@ -1,5 +1,4 @@
 import { supabase } from '@/lib/supabase';
-import { embeddingService } from './embeddingService';
 
 export interface VectorSearchResult {
   title_id: string;
@@ -19,11 +18,20 @@ export interface VectorSearchOptions {
   limit?: number; // Maximum number of results
 }
 
+interface VectorSearchResponse {
+  results: VectorSearchResult[];
+  query: string;
+  count: number;
+  processing_time_ms: number;
+  cost_estimate: number;
+  error?: string;
+}
+
 /**
- * Simplified Vector Search Service for Dashboard-Next
+ * Vector Search Service for Dashboard
  *
  * Provides semantic search for titles using OpenAI embeddings
- * and PostgreSQL vector similarity search.
+ * via the vector-search edge function.
  *
  * Performance: ~1-2 seconds (embedding generation + vector search)
  * Cost: ~$0.0001 per search
@@ -48,37 +56,40 @@ class VectorSearchService {
     try {
       console.log(`🔍 Starting vector search for: "${query}"`);
 
-      // Step 1: Generate embedding for the search query
-      console.log('🔄 Generating embedding for search query...');
-      const embeddingResult = await embeddingService.generateEmbedding(query);
-
-      if (!embeddingResult) {
-        throw new Error('Failed to generate query embedding');
-      }
-
-      console.log(`✅ Embedding generated (${embeddingResult.usage.total_tokens} tokens used)`);
-
-      // Step 2: Perform vector similarity search via RPC function
       const threshold = options?.threshold || this.DEFAULT_MATCH_THRESHOLD;
       const limit = options?.limit || this.DEFAULT_RESULT_COUNT;
 
-      console.log(`🔍 Searching with threshold=${threshold}, limit=${limit}...`);
+      console.log(`🔄 Calling vector-search edge function...`);
 
-      const { data: results, error } = await supabase.rpc('match_titles_by_embedding', {
-        query_embedding: embeddingResult.embedding,
-        match_threshold: threshold,
-        match_count: limit
+      // Call edge function (secure server-side embedding generation)
+      const { data, error } = await supabase.functions.invoke<VectorSearchResponse>('vector-search', {
+        body: {
+          query,
+          match_threshold: threshold,
+          match_count: limit,
+        },
       });
 
       if (error) {
-        console.error('❌ Vector search RPC error:', error);
+        console.error('❌ Vector search edge function error:', error);
         throw new Error(`Vector search failed: ${error.message}`);
       }
 
-      const searchResults = results || [];
+      if (data?.error) {
+        console.error('❌ Vector search returned error:', data.error);
+        throw new Error(data.error);
+      }
+
+      const searchResults = data?.results || [];
       const searchDuration = Date.now() - startTime;
 
       console.log(`✅ Vector search complete: ${searchResults.length} results in ${searchDuration}ms`);
+      if (data?.processing_time_ms) {
+        console.log(`📊 Server processing time: ${data.processing_time_ms}ms`);
+      }
+      if (data?.cost_estimate) {
+        console.log(`💰 Cost: $${data.cost_estimate.toFixed(6)}`);
+      }
 
       if (searchResults.length > 0) {
         console.log(`📊 Similarity range: ${searchResults[0]?.similarity?.toFixed(3)} to ${searchResults[searchResults.length - 1]?.similarity?.toFixed(3)}`);

--- a/supabase/functions/vector-search/index.ts
+++ b/supabase/functions/vector-search/index.ts
@@ -1,0 +1,169 @@
+// Edge Function: vector-search
+// Version: 1.0
+// Created: 2025-11-28
+// Description: Semantic vector search for titles using OpenAI embeddings
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
+
+const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+interface VectorSearchRequest {
+  query: string;
+  match_threshold?: number;
+  match_count?: number;
+}
+
+interface VectorSearchResult {
+  title_id: string;
+  title_name_en?: string;
+  title_name_kr?: string;
+  synopsis?: string;
+  description?: string;
+  genre?: string[];
+  tone?: string;
+  content_format?: string;
+  title_image?: string;
+  similarity: number;
+}
+
+interface VectorSearchResponse {
+  results: VectorSearchResult[];
+  query: string;
+  count: number;
+  processing_time_ms: number;
+  cost_estimate: number;
+}
+
+serve(async (req) => {
+  const startTime = Date.now();
+
+  // CORS headers
+  if (req.method === "OPTIONS") {
+    return new Response(null, {
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "POST, OPTIONS",
+        "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+      },
+    });
+  }
+
+  try {
+    // Validate OpenAI API key
+    if (!OPENAI_API_KEY) {
+      throw new Error("OPENAI_API_KEY not configured");
+    }
+
+    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+    // Parse request
+    const {
+      query,
+      match_threshold = 0.4,
+      match_count = 30
+    }: VectorSearchRequest = await req.json();
+
+    if (!query?.trim()) {
+      return new Response(
+        JSON.stringify({ error: "Query is required" }),
+        {
+          status: 400,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
+        }
+      );
+    }
+
+    console.log(`🔍 Vector search for: "${query.substring(0, 100)}..."`);
+
+    // Step 1: Generate embedding for query using OpenAI
+    console.log("📊 Generating embedding...");
+    const embeddingResponse = await fetch("https://api.openai.com/v1/embeddings", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${OPENAI_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        input: query,
+        model: "text-embedding-ada-002",
+      }),
+    });
+
+    if (!embeddingResponse.ok) {
+      const error = await embeddingResponse.text();
+      throw new Error(`OpenAI API error: ${error}`);
+    }
+
+    const embeddingData = await embeddingResponse.json();
+    const embedding = embeddingData.data[0].embedding;
+
+    // Calculate embedding cost (text-embedding-ada-002: $0.0001 per 1K tokens)
+    const tokens = embeddingData.usage.total_tokens;
+    const embeddingCost = (tokens / 1000) * 0.0001;
+
+    console.log(`✅ Embedding generated (${tokens} tokens, $${embeddingCost.toFixed(6)})`);
+
+    // Step 2: Vector search using RPC function
+    console.log(`🔍 Searching with threshold=${match_threshold}, limit=${match_count}...`);
+    const { data: searchResults, error: searchError } = await supabase.rpc(
+      "match_titles_by_embedding",
+      {
+        query_embedding: embedding,
+        match_threshold: match_threshold,
+        match_count: match_count,
+      }
+    );
+
+    if (searchError) {
+      throw new Error(`Vector search error: ${searchError.message}`);
+    }
+
+    const results: VectorSearchResult[] = searchResults || [];
+    const processingTime = Date.now() - startTime;
+
+    console.log(`✅ Vector search complete: ${results.length} results in ${processingTime}ms`);
+    console.log(`💰 Cost: $${embeddingCost.toFixed(6)}`);
+
+    if (results.length > 0) {
+      console.log(`📊 Similarity range: ${results[0]?.similarity?.toFixed(3)} to ${results[results.length - 1]?.similarity?.toFixed(3)}`);
+    }
+
+    const response: VectorSearchResponse = {
+      results,
+      query,
+      count: results.length,
+      processing_time_ms: processingTime,
+      cost_estimate: embeddingCost,
+    };
+
+    return new Response(JSON.stringify(response), {
+      headers: {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  } catch (error) {
+    const processingTime = Date.now() - startTime;
+    console.error(`❌ Vector search error after ${processingTime}ms:`, error);
+
+    return new Response(
+      JSON.stringify({
+        error: error.message,
+        details: error.toString(),
+      }),
+      {
+        status: 500,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- Create vector-search edge function for secure server-side embedding generation
- Update vectorSearchService.ts to call edge function instead of client-side OpenAI
- Fixes production error: "OpenAI client not initialized"

## Problem
Vector search on the titles page was failing in production with the error:
```
OpenAI client not initialized. Check VITE_OPENAI_API_KEY in .env.local
```

**Root Cause**: The implementation used client-side OpenAI calls (`embeddingService.ts` with `dangerouslyAllowBrowser: true`) which:
1. Required `VITE_OPENAI_API_KEY` in Vercel environment variables (not set)
2. Exposed the API key to client-side JavaScript (security vulnerability)

## Solution
Created a new `vector-search` edge function following the established pattern from `mandate-matcher` and `comp-navigator`. This:
1. Keeps the API key secure on the server
2. Uses the existing `OPENAI_API_KEY` secret (already set for mandate-matcher)
3. Follows the same architecture as all other AI features in the codebase

## Test plan
- [x] Build passes (`npm run build`)
- [x] Edge function deployed (`npx supabase functions deploy vector-search`)
- [ ] Test vector search on production titles page

🤖 Generated with [Claude Code](https://claude.com/claude-code)