### PR TITLE
fix: Remove unused comp_alignments from Comps Navigator components

### DIFF
--- a/apps/dashboard/src/components/comps-navigator/MatchDetailModal.tsx
+++ b/apps/dashboard/src/components/comps-navigator/MatchDetailModal.tsx
@@ -3,7 +3,6 @@
  *
  * Modal showing full match details:
  * - Full explanation
- * - Individual comp alignments with scores and reasons
  * - Link to full title detail page
  */
 
@@ -28,13 +27,6 @@ export default function MatchDetailModal({ match, onClose }: MatchDetailModalPro
 
   const handleViewFullTitle = () => {
     navigate(`/buyers/titles/${match.title_id}`);
-  };
-
-  const getScoreColor = (score: number) => {
-    if (score >= 85) return 'text-green-600';
-    if (score >= 70) return 'text-blue-600';
-    if (score >= 50) return 'text-yellow-600';
-    return 'text-gray-600';
   };
 
   return (
@@ -104,33 +96,6 @@ export default function MatchDetailModal({ match, onClose }: MatchDetailModalPro
             <h3 className="text-lg font-semibold text-gray-900 mb-2">Why This Matches</h3>
             <p className="text-sm text-gray-700">{match.explanation}</p>
           </div>
-
-          {/* Individual Comp Alignments */}
-          {match.comp_alignments && match.comp_alignments.length > 0 && (
-            <div>
-              <h3 className="text-lg font-semibold text-gray-900 mb-3">Comp Alignment Breakdown</h3>
-              <div className="space-y-4">
-                {match.comp_alignments.map((alignment, idx) => (
-                  <div key={idx} className="border border-gray-200 rounded-lg p-4">
-                    <div className="flex items-center justify-between mb-2">
-                      <h4 className="font-semibold text-gray-900">{alignment.comp_title}</h4>
-                      <span className={`text-2xl font-bold ${getScoreColor(alignment.alignment_score)}`}>
-                        {alignment.alignment_score}%
-                      </span>
-                    </div>
-                    <ul className="space-y-1">
-                      {alignment.reasons.map((reason, ridx) => (
-                        <li key={ridx} className="text-sm text-gray-600 flex items-start">
-                          <span className="text-blue-500 mr-2">•</span>
-                          <span>{reason}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
 
           {/* Actions */}
           <div className="flex gap-3 pt-4 border-t border-gray-200">

--- a/apps/dashboard/src/components/comps-navigator/TitleMatchCard.tsx
+++ b/apps/dashboard/src/components/comps-navigator/TitleMatchCard.tsx
@@ -107,7 +107,7 @@ export default function TitleMatchCard({ match }: TitleMatchCardProps) {
             </div>
 
             {/* Match Explanation - AI Chat Bubble */}
-            <div className="flex gap-3 mb-4">
+            <div className="flex gap-3">
               <div className="flex-shrink-0">
                 <div className="bg-hanok-teal/10 rounded-full p-2">
                   <Bot className="h-5 w-5 text-hanok-teal" />
@@ -119,28 +119,6 @@ export default function TitleMatchCard({ match }: TitleMatchCardProps) {
                 </p>
               </div>
             </div>
-
-            {/* Comp Alignments */}
-            {match.comp_alignments && match.comp_alignments.length > 0 && (
-              <div className="space-y-2">
-                <div className="text-xs font-semibold text-gray-700 uppercase tracking-wide">Comp Alignments</div>
-                {match.comp_alignments.slice(0, 2).map((alignment, idx) => (
-                  <div key={idx} className="flex items-center justify-between">
-                    <span className="bg-gradient-to-r from-emerald-100 to-emerald-50 text-emerald-800 px-2 py-1 rounded-md text-xs font-medium border border-emerald-200">
-                      {alignment.comp_title}
-                    </span>
-                    <span className="text-xs font-bold text-gray-700">
-                      {alignment.alignment_score}%
-                    </span>
-                  </div>
-                ))}
-                {match.comp_alignments.length > 2 && (
-                  <div className="text-xs text-gray-500 italic">
-                    +{match.comp_alignments.length - 2} more
-                  </div>
-                )}
-              </div>
-            )}
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary

- Remove references to `comp_alignments` from TitleMatchCard and MatchDetailModal
- The field was removed from TitleMatch interface but components still referenced it, causing TypeScript build errors on main

## Test plan

- [ ] Build passes: `npm run build:dashboard`
- [ ] Comps Navigator search results display correctly without comp alignment breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)