### PR TITLE
fix: Fix trial page TierProvider error and dialog accessibility warnings

### DIFF
--- a/apps/dashboard/src/components/trial/TrialCompsSection.tsx
+++ b/apps/dashboard/src/components/trial/TrialCompsSection.tsx
@@ -13,7 +13,7 @@ import { compsNavigatorService, TitleMatch } from '@/services/compsNavigatorServ
 import { CompTitle } from '@/components/comps-navigator/CompSelector';
 import CompsNavigatorInput from '@/components/comps-navigator/CompsNavigatorInput';
 import ExamplesSection from '@/components/comps-navigator/ExamplesSection';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { TrialResultsGrid } from './TrialResultsGrid';
 
 type LoadingPhase = 'semantic' | 'reranking' | null;
@@ -158,9 +158,9 @@ export function TrialCompsSection() {
             <DialogTitle className="text-lg sm:text-xl font-bold text-hanok-teal">
               Explore Example Combinations
             </DialogTitle>
-            <p className="text-sm text-gray-600 mt-1">
+            <DialogDescription className="text-sm text-gray-600 mt-1">
               Learn how to combine comps effectively by trying these curated examples
-            </p>
+            </DialogDescription>
           </DialogHeader>
           <div className="flex-1 overflow-y-auto px-4 py-4 sm:px-6">
             <ExamplesSection

--- a/apps/dashboard/src/components/trial/TrialMandatesSection.tsx
+++ b/apps/dashboard/src/components/trial/TrialMandatesSection.tsx
@@ -12,7 +12,7 @@ import { useTrial } from '@/contexts/TrialContext';
 import { mandateService, TitleMatch } from '@/services/mandateService';
 import MandateSearchInput from '@/components/mandates/MandateSearchInput';
 import MandateExamples from '@/components/mandates/MandateExamples';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { TrialMandateResultsGrid } from './TrialMandateResultsGrid';
 
 export function TrialMandatesSection() {
@@ -120,9 +120,9 @@ export function TrialMandatesSection() {
             <DialogTitle className="text-lg sm:text-xl font-bold text-purple-600">
               Example Mandates
             </DialogTitle>
-            <p className="text-sm text-gray-600 mt-1">
+            <DialogDescription className="text-sm text-gray-600 mt-1">
               Learn how to write effective mandate descriptions with these examples
-            </p>
+            </DialogDescription>
           </DialogHeader>
           <div className="flex-1 overflow-y-auto px-4 py-4 sm:px-6">
             <MandateExamples

--- a/apps/dashboard/src/components/trial/TrialResultsGrid.tsx
+++ b/apps/dashboard/src/components/trial/TrialResultsGrid.tsx
@@ -13,6 +13,7 @@ import { TitleMatch } from '@/services/compsNavigatorService';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
@@ -145,6 +146,9 @@ function TrialMatchDetailModal({ match, onClose }: { match: TitleMatch; onClose:
           <DialogTitle className="text-2xl font-bold">
             {match.title_name_en || match.title_name_kr}
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            Detailed match information for {match.title_name_en || match.title_name_kr}
+          </DialogDescription>
           {match.title_name_en && match.title_name_kr && (
             <p className="text-gray-500">{match.title_name_kr}</p>
           )}

--- a/apps/dashboard/src/contexts/TierContext.tsx
+++ b/apps/dashboard/src/contexts/TierContext.tsx
@@ -117,10 +117,25 @@ export function TierProvider({ children }: { children: ReactNode }) {
   );
 }
 
+/**
+ * Hook to access tier context.
+ * Returns a default "unrestricted" state when used outside TierProvider
+ * (e.g., in trial pages where all content should be accessible).
+ */
 export function useTierAccess() {
   const context = useContext(TierContext);
+
+  // When outside TierProvider (e.g., trial pages), return permissive defaults
+  // This allows TierGatedContent to show content without tier restrictions
   if (context === undefined) {
-    throw new Error('useTierAccess must be used within a TierProvider');
+    return {
+      tier: 'basic' as UserTier,
+      loading: false,
+      hasAccess: () => true, // Always grant access in trial mode
+      refetch: async () => {},
+      error: null,
+    };
   }
+
   return context;
 }


### PR DESCRIPTION
## Summary
- Fix critical error on `/trial/titles/:titleId` page: "useTierAccess must be used within a TierProvider"
- Fix accessibility warnings for missing DialogDescription in trial modals

## Changes
- **TierContext.tsx**: Update `useTierAccess` hook to return permissive defaults when used outside TierProvider (allows trial pages to work without TierProvider wrapper)
- **TrialResultsGrid.tsx**: Add DialogDescription for match detail modal
- **TrialCompsSection.tsx**: Convert `<p>` to `<DialogDescription>` in examples modal
- **TrialMandatesSection.tsx**: Convert `<p>` to `<DialogDescription>` in examples modal

## Test plan
- [ ] Visit `/trial` page - verify no console errors
- [ ] Click on a title in Comps Navigator results - verify modal opens without errors
- [ ] Visit `/trial/titles/:titleId` - verify page loads without TierProvider error
- [ ] Check console for any remaining accessibility warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)