### PR TITLE
fix: TypeScript error in useOMDBAutocomplete test

### DIFF
--- a/apps/dashboard/src/hooks/useOMDBAutocomplete.test.ts
+++ b/apps/dashboard/src/hooks/useOMDBAutocomplete.test.ts
@@ -54,8 +54,8 @@ describe('useOMDBAutocomplete', () => {
       expect(result.current.suggestions).toEqual([]);
     });
 
-    it('should accept debounceMs option', () => {
-      const { result } = renderHook(() => useOMDBAutocomplete('test', { debounceMs: 500 }));
+    it('should accept minChars option', () => {
+      const { result } = renderHook(() => useOMDBAutocomplete('test', { minChars: 3 }));
 
       // Hook should initialize without errors
       expect(result.current.suggestions).toEqual([]);


### PR DESCRIPTION
## Summary
- Fix TypeScript build error: Replace non-existent `debounceMs` option with valid `minChars` option in test

## Problem
The previous deployment to main failed with:
```
src/hooks/useOMDBAutocomplete.test.ts(58,73): error TS2353: Object literal may only specify known properties, and 'debounceMs' does not exist in type 'UseOMDBAutocompleteOptions'.
```

## Solution
Changed test from using invalid `debounceMs: 500` to valid `minChars: 3` option.

## Test plan
- [x] Build passes locally
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)