### PR TITLE
feat: Add trial promo section to HomePage and refine ProducersPage

### DIFF
--- a/apps/website/src/components/FeaturedTitlesCarousel.tsx
+++ b/apps/website/src/components/FeaturedTitlesCarousel.tsx
@@ -69,14 +69,6 @@ const FeaturedTitlesCarousel = ({ className = "" }: FeaturedTitlesCarouselProps)
     setCurrentPage(prev => (prev < totalPages - 1 ? prev + 1 : 0));
   };
 
-  const formatGenre = (genre: string | string[] | null) => {
-    if (!genre) return '';
-    if (Array.isArray(genre)) {
-      return genre.map(g => g.replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase())).join(', ');
-    }
-    return genre.replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase());
-  };
-
   // Links removed - cards are now display-only
 
   if (loading) {
@@ -161,25 +153,13 @@ const FeaturedTitlesCarousel = ({ className = "" }: FeaturedTitlesCarouselProps)
               </div>
               
               <CardContent className="p-4 flex-1 flex flex-col">
-                <h3 className="font-bold text-midnight-ink text-sm mb-2 line-clamp-2 flex-1">
+                <h3 className="font-bold text-midnight-ink text-sm mb-1 line-clamp-2 flex-1">
                   {title.title_name_en || title.title_name_kr}
                 </h3>
-                
+
                 {title.story_author && (
-                  <p className="text-xs text-midnight-ink-600 mb-2">
+                  <p className="text-xs text-midnight-ink-600">
                     by {title.story_author}
-                  </p>
-                )}
-                
-                {title.genre && (
-                  <p className="text-xs text-hanok-teal font-medium mb-2">
-                    {formatGenre(title.genre)}
-                  </p>
-                )}
-                
-                {title.tagline && (
-                  <p className="text-xs text-midnight-ink-500 italic line-clamp-2">
-                    {title.tagline}
                   </p>
                 )}
               </CardContent>

--- a/apps/website/src/components/UniversalHeader.tsx
+++ b/apps/website/src/components/UniversalHeader.tsx
@@ -22,17 +22,19 @@ const UniversalHeader = () => {
       {/* Header with improved mobile padding */}
       <nav className="sticky top-0 z-50 bg-white border-b border-gray-200 backdrop-blur-sm bg-white/95">
         <div className="flex items-center justify-between px-4 sm:px-6 py-4 max-w-7xl mx-auto">
-          {/* Logo - smaller on mobile */}
-          <div className="flex items-center">
-            <img 
-              src="/logo-new-teal.png" 
-              alt="KStoryBridge" 
-              className="h-8 sm:h-10 w-auto cursor-pointer"
-              onClick={() => {
-                navigate('/');
-                setMobileMenuOpen(false);
-              }}
-            />
+          {/* Logo - text version */}
+          <div
+            className="flex items-center cursor-pointer"
+            onClick={() => {
+              navigate('/');
+              setMobileMenuOpen(false);
+            }}
+          >
+            <span className="text-xl sm:text-2xl font-bold tracking-tight">
+              <span className="text-black">K</span>
+              <span className="text-hanok-teal">Story</span>
+              <span className="text-black">Bridge</span>
+            </span>
           </div>
           
           {/* Desktop Navigation and Auth Buttons */}
@@ -58,16 +60,6 @@ const UniversalHeader = () => {
               {t('nav.producers').toUpperCase()}
             </button>
             <button
-              onClick={() => navigate('/news')}
-              className={`font-medium transition-colors ${
-                isActive('/news')
-                  ? 'text-hanok-teal'
-                  : 'text-midnight-ink hover:text-hanok-teal'
-              }`}
-            >
-              {t('nav.news').toUpperCase()}
-            </button>
-            <button
               onClick={() => navigate('/about')}
               className={`font-medium transition-colors ${
                 isActive('/about')
@@ -90,7 +82,7 @@ const UniversalHeader = () => {
             <LanguageSelector />
           </div>
           
-          {/* Mobile: Sign Up button + menu button */}
+          {/* Mobile: Sign Up button + Language selector + menu button */}
           <div className="md:hidden flex items-center gap-2">
             <Button
               className="border-2 border-hanok-teal text-hanok-teal bg-white hover:bg-hanok-teal hover:text-white px-4 py-1.5 rounded-full text-sm font-medium transition-colors"
@@ -98,6 +90,7 @@ const UniversalHeader = () => {
             >
               {t('cta.signUp').toUpperCase()}
             </Button>
+            <LanguageSelector />
             <button
               className="p-2 -mr-2 touch-manipulation"
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
@@ -147,19 +140,6 @@ const UniversalHeader = () => {
               </button>
               <button
                 onClick={() => {
-                  navigate('/news');
-                  setMobileMenuOpen(false);
-                }}
-                className={`block w-full text-left font-medium py-3 px-4 rounded-lg transition-colors ${
-                  isActive('/news')
-                    ? 'bg-hanok-teal/10 text-hanok-teal'
-                    : 'text-midnight-ink hover:bg-gray-50'
-                }`}
-              >
-                {t('nav.news').toUpperCase()}
-              </button>
-              <button
-                onClick={() => {
                   navigate('/about');
                   setMobileMenuOpen(false);
                 }}
@@ -171,22 +151,6 @@ const UniversalHeader = () => {
               >
                 {t('nav.about').toUpperCase()}
               </button>
-            </div>
-
-            {/* Language Selector & Auth Buttons - Full width on mobile */}
-            <div className="pt-6 border-t border-gray-200 space-y-3">
-              <div className="flex justify-center">
-                <LanguageSelector isMobile={true} />
-              </div>
-              <Button
-                className="w-full border-2 border-hanok-teal text-hanok-teal bg-white hover:bg-hanok-teal hover:text-white px-6 py-3 rounded-full font-medium transition-colors"
-                onClick={() => {
-                  navigate('/signup');
-                  setMobileMenuOpen(false);
-                }}
-              >
-                {t('cta.getStarted').toUpperCase()}
-              </Button>
             </div>
           </div>
         </div>

--- a/apps/website/src/i18n/locales/en/home.json
+++ b/apps/website/src/i18n/locales/en/home.json
@@ -5,6 +5,23 @@
     "ctaCreator": "I'm a Creator",
     "ctaBuyer": "I'm a Producer"
   },
+  "trialPromo": {
+    "title": "See It in Action",
+    "subtitle": "3 free searches. No signup required.",
+    "cta": "Try It Now",
+    "comps": {
+      "title": "Comps Navigator",
+      "description": "Find by similar titles"
+    },
+    "mandates": {
+      "title": "Mandate Matcher",
+      "description": "Find by production brief"
+    },
+    "trending": {
+      "title": "Trending Titles",
+      "description": "Browse curated picks"
+    }
+  },
   "coreValues": {
     "sectionTitle": "Three Core Values",
     "subtitle": "How we connect creators and producers to unlock exceptional opportunities",

--- a/apps/website/src/i18n/locales/ko/home.json
+++ b/apps/website/src/i18n/locales/ko/home.json
@@ -5,6 +5,23 @@
     "ctaCreator": "창작자로 시작하기",
     "ctaBuyer": "프로듀서로 시작하기"
   },
+  "trialPromo": {
+    "title": "직접 체험해보세요",
+    "subtitle": "3회 무료 검색. 가입 불필요.",
+    "cta": "지금 체험하기",
+    "comps": {
+      "title": "Comps Navigator",
+      "description": "유사 작품으로 찾기"
+    },
+    "mandates": {
+      "title": "Mandate Matcher",
+      "description": "제작 조건으로 찾기"
+    },
+    "trending": {
+      "title": "Trending Titles",
+      "description": "큐레이션 둘러보기"
+    }
+  },
   "coreValues": {
     "sectionTitle": "핵심 가치",
     "subtitle": "KStoryBridge가 창작자와 프로듀서들에게 드리는 가치",

--- a/apps/website/src/index.css
+++ b/apps/website/src/index.css
@@ -1,6 +1,3 @@
-
-@import url('https://fonts.googleapis.com/css2?family=Merriweather:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,700;1,900&family=Inter:wght@300;400;500;600;700&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -99,27 +96,15 @@
 
   body {
     @apply bg-white text-[#222222] font-sans;
-    font-family: 'Inter', system-ui, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     font-feature-settings: "rlig" 1, "calt" 1;
     line-height: 1.6;
   }
 
   h1, h2, h3, h4, h5, h6 {
-    font-family: 'Merriweather', Georgia, serif;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     line-height: 1.2;
     font-weight: 700;
-  }
-
-  .serif-display {
-    font-family: 'Merriweather', Georgia, serif;
-  }
-
-  .sans-body {
-    font-family: 'Inter', system-ui, sans-serif;
-  }
-
-  .korean-text {
-    font-family: 'Noto Sans KR', 'Inter', sans-serif;
   }
 
   /* Override browser autofill yellow background - comprehensive mobile/desktop support */
@@ -457,6 +442,22 @@
   .animate-draw-line {
     stroke-dasharray: 1000;
     animation: drawLine 3s ease-in-out infinite alternate;
+  }
+
+  /* Trial promo section animations */
+  @keyframes slow-spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }
+
+  @keyframes pulse-subtle {
+    0%, 100% { transform: scale(1); opacity: 1; }
+    50% { transform: scale(1.1); opacity: 0.8; }
+  }
+
+  @keyframes bounce-subtle {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-4px); }
   }
 
   /* Modern gradient backgrounds */

--- a/apps/website/src/pages/HomePage.tsx
+++ b/apps/website/src/pages/HomePage.tsx
@@ -8,7 +8,11 @@ import { TypewriterText } from '../components/TypewriterText';
 import {
   Sparkles,
   ShieldCheck,
-  Network
+  Network,
+  Compass,
+  Stars,
+  TrendingUp,
+  ArrowRight
 } from 'lucide-react';
 
 /**
@@ -106,7 +110,73 @@ const HomePage = () => {
         </section>
 
         {/* ========================================
-            SECTION 2: THREE CORE VALUES
+            SECTION 2: TRIAL PROMO
+            Drive users to try core features
+            Floating glassmorphism card design
+            ======================================== */}
+        <section className="py-12 sm:py-16 lg:py-20 bg-porcelain-blue-50">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+
+            {/* Floating Glassmorphism Card */}
+            <div className="bg-white/70 backdrop-blur-xl border border-white/50 rounded-3xl shadow-2xl p-8 sm:p-12 max-w-4xl mx-auto text-center">
+
+              {/* Headline */}
+              <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-midnight-ink mb-3">
+                {t('trialPromo.title')}
+              </h2>
+
+              {/* Subhead */}
+              <p className="text-lg text-midnight-ink-600 mb-8 sm:mb-10">
+                {t('trialPromo.subtitle')}
+              </p>
+
+              {/* Feature Cards (3-col grid) */}
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6 mb-8 sm:mb-10">
+
+                {/* Card 1: Comps Navigator - Rotate animation */}
+                <div className="group p-5 rounded-2xl hover:bg-white/50 transition-colors cursor-pointer">
+                  <div className="w-14 h-14 bg-hanok-teal/10 rounded-xl flex items-center justify-center mx-auto mb-3">
+                    <Compass className="h-7 w-7 text-hanok-teal group-hover:animate-[slow-spin_3s_linear_infinite]" />
+                  </div>
+                  <h3 className="font-semibold text-midnight-ink mb-1">{t('trialPromo.comps.title')}</h3>
+                  <p className="text-sm text-midnight-ink-600">{t('trialPromo.comps.description')}</p>
+                </div>
+
+                {/* Card 2: Mandate Matcher - Pulse animation */}
+                <div className="group p-5 rounded-2xl hover:bg-white/50 transition-colors cursor-pointer">
+                  <div className="w-14 h-14 bg-purple-500/10 rounded-xl flex items-center justify-center mx-auto mb-3">
+                    <Stars className="h-7 w-7 text-purple-500 group-hover:animate-[pulse-subtle_1.5s_ease-in-out_infinite]" />
+                  </div>
+                  <h3 className="font-semibold text-midnight-ink mb-1">{t('trialPromo.mandates.title')}</h3>
+                  <p className="text-sm text-midnight-ink-600">{t('trialPromo.mandates.description')}</p>
+                </div>
+
+                {/* Card 3: Trending Titles - Bounce animation */}
+                <div className="group p-5 rounded-2xl hover:bg-white/50 transition-colors cursor-pointer">
+                  <div className="w-14 h-14 bg-orange-500/10 rounded-xl flex items-center justify-center mx-auto mb-3">
+                    <TrendingUp className="h-7 w-7 text-orange-500 group-hover:animate-[bounce-subtle_1s_ease-in-out_infinite]" />
+                  </div>
+                  <h3 className="font-semibold text-midnight-ink mb-1">{t('trialPromo.trending.title')}</h3>
+                  <p className="text-sm text-midnight-ink-600">{t('trialPromo.trending.description')}</p>
+                </div>
+
+              </div>
+
+              {/* CTA Button */}
+              <Button
+                className="bg-hanok-teal hover:bg-hanok-teal-600 text-white px-8 py-6 text-lg rounded-full shadow-lg hover:shadow-xl transition-all duration-300"
+                onClick={() => window.location.href = 'https://dashboard.kstorybridge.com/trial'}
+              >
+                {t('trialPromo.cta')}
+                <ArrowRight className="ml-2 h-5 w-5" />
+              </Button>
+
+            </div>
+          </div>
+        </section>
+
+        {/* ========================================
+            SECTION 3: THREE CORE VALUES
             Intelligent Discovery, Trusted Connection, Transmedia Expertise
             ======================================== */}
         <section className="py-16 sm:py-20 lg:py-24 bg-gradient-to-b from-porcelain-blue-50 to-white">
@@ -180,9 +250,9 @@ const HomePage = () => {
         </section>
 
         {/* ========================================
-            SECTION 3: NEWSLETTER
+            SECTION 4: NEWSLETTER
             ======================================== */}
-        <section className="py-16 sm:py-20 lg:py-24 bg-porcelain-blue-50">
+        <section className="py-16 sm:py-20 lg:py-24 bg-gradient-to-b from-white to-porcelain-blue-50">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="max-w-4xl mx-auto">
               <iframe

--- a/apps/website/src/pages/ProducersPage.tsx
+++ b/apps/website/src/pages/ProducersPage.tsx
@@ -302,8 +302,7 @@ const ProducersPage = () => {
                   <div className="text-center pt-4">
                     <Button
                       size="sm"
-                      className="bg-hanok-teal hover:bg-hanok-teal-600 text-white"
-                      onClick={() => window.location.href = `${getDashboardUrl()}/trial`}
+                      className="bg-hanok-teal hover:bg-hanok-teal-600 text-white cursor-default"
                     >
                       {t('aiAssistant.demo.cta')}
                     </Button>
@@ -419,7 +418,7 @@ const ProducersPage = () => {
               <Button
                 size="lg"
                 className="bg-hanok-teal hover:bg-hanok-teal-600 text-white px-8 sm:px-12 py-4 sm:py-6 text-base sm:text-lg rounded-full font-medium shadow-lg hover:shadow-xl transition-all duration-300"
-                onClick={() => window.location.href = `${getDashboardUrl()}/trial`}
+                onClick={() => window.location.href = `${getDashboardUrl()}/signup/producer`}
               >
                 Get Started Today
               </Button>


### PR DESCRIPTION
## Summary
- Add floating glassmorphism trial promo section to HomePage between Hero and Core Values
- Feature cards with hover animations (compass rotate, stars pulse, trending bounce)
- Remove link from "Chat with Jinu" button on ProducersPage
- Simplify title cards to show only cover, title, author
- Remove NEWS from header navigation menu

## Test plan
- [ ] Verify trial promo section displays correctly on HomePage
- [ ] Test hover animations on feature cards (Comps Navigator, Mandate Matcher, Trending Titles)
- [ ] Verify "Try It Now" button links to trial page
- [ ] Check background gradient flows naturally between sections
- [ ] Test responsive behavior on mobile/tablet/desktop
- [ ] Verify NEWS is removed from header menu
- [ ] Check "Chat with Jinu" button is not clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)