### PR TITLE
docs: Add Comps Navigator sample data documentation

### DIFF
--- a/apps/dashboard/src/pages/admin/Docs.tsx
+++ b/apps/dashboard/src/pages/admin/Docs.tsx
@@ -1,0 +1,584 @@
+/**
+ * Admin Documentation Viewer
+ *
+ * Displays curated internal documentation for admins.
+ * Fetches markdown files at runtime from GitHub raw content.
+ */
+
+import { useState, useEffect, useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { Icon } from '@iconify/react';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import { cn } from '@/lib/utils';
+
+interface DocItem {
+  id: string;
+  name: string;
+  path: string;
+  inlineContent?: string; // For docs with embedded content instead of fetching
+  content?: string;
+  loading?: boolean;
+  error?: boolean;
+}
+
+interface DocCategory {
+  id: string;
+  name: string;
+  icon: string;
+  docs: DocItem[];
+}
+
+// Define documentation categories with curated docs
+const DOC_CATEGORIES: DocCategory[] = [
+  {
+    id: 'core',
+    name: 'Core System',
+    icon: 'solar:server-bold-duotone',
+    docs: [
+      { id: 'auth', name: 'Authentication', path: 'docs/active/AUTH_DOCUMENTATION.md' },
+      { id: 'database', name: 'Database Schema', path: 'docs/active/DATABASE_SCHEMA.md' },
+      { id: 'design', name: 'Design System', path: 'docs/active/DESIGN_SYSTEM.md' },
+      { id: 'cache', name: 'Cache Policy', path: 'docs/active/CACHE_POLICY.md' },
+      { id: 'security', name: 'Security Best Practices', path: 'docs/active/SECURITY_BEST_PRACTICES.md' },
+      { id: 'email', name: 'Email Policy', path: 'docs/active/EMAIL_POLICY_DOCUMENTATION.md' },
+      { id: 'user-journey', name: 'User Journey Map', path: 'docs/active/USER_JOURNEY_MAP.md' },
+      { id: 'tier-system', name: 'Tier System Manual', path: 'docs/active/TIER_SYSTEM_MANUAL.md' },
+      { id: 'tier-features', name: 'Tier Features', path: 'docs/active/BUYER_TIER_FEATURES_MANUAL.md' },
+      { id: 'local-prod', name: 'Local vs Production', path: 'docs/active/LOCAL_VS_PRODUCTION_DIFFERENCES.md' },
+    ],
+  },
+  {
+    id: 'guides',
+    name: 'Setup Guides',
+    icon: 'solar:book-2-bold-duotone',
+    docs: [
+      { id: 'turborepo', name: 'Turborepo Setup', path: 'docs/guides/TURBOREPO_VERCEL_SETUP.md' },
+      { id: 'git-deploy', name: 'Git Deployment', path: 'docs/guides/GIT_DEPLOYMENT_STRUCTURE.md' },
+      { id: 'deploy-strategy', name: 'Deployment Strategy', path: 'docs/guides/DEPLOYMENT_STRATEGY.md' },
+      { id: 'deploy-instructions', name: 'Deployment Instructions', path: 'docs/guides/DEPLOYMENT_INSTRUCTIONS.md' },
+      { id: 'stripe-setup', name: 'Stripe Setup', path: 'docs/guides/STRIPE_SETUP_GUIDE.md' },
+      { id: 'openai-setup', name: 'OpenAI Setup', path: 'docs/guides/OPENAI_PRODUCTION_SETUP.md' },
+      { id: 'migration-safety', name: 'Migration Safety', path: 'docs/guides/MIGRATION_SAFETY_GUIDE.md' },
+      { id: 'field-naming', name: 'Field Naming Standards', path: 'docs/guides/FIELD_NAMING_STANDARDS.md' },
+    ],
+  },
+  {
+    id: 'features',
+    name: 'Features',
+    icon: 'solar:stars-bold-duotone',
+    docs: [
+      { id: 'title-intel', name: 'Title Intelligence', path: 'docs/features/TITLE_INTELLIGENCE.md' },
+      { id: 'comps-navigator', name: 'Comps Navigator', path: 'docs/features/COMPS_NAVIGATOR_PLAN.md' },
+      { id: 'comps-samples', name: 'Comps Sample Data', path: 'docs/features/COMPS_NAVIGATOR_SAMPLES.md' },
+      { id: 'chatbot-overview', name: 'AI Chatbot Overview', path: 'docs/features/chatbot/OVERVIEW.md' },
+      { id: 'chatbot-testing', name: 'Chatbot Testing', path: 'docs/features/chatbot/TESTING_GUIDE.md' },
+      { id: 'pitch-analytics', name: 'Pitch Analytics', path: 'docs/features/chatbot/PITCH_ANALYTICS.md' },
+      { id: 'comps-optimization', name: 'Comps Optimization', path: 'docs/features/comps-navigator/OPTIMIZATION_COMPLETE.md' },
+    ],
+  },
+  {
+    id: 'product',
+    name: 'Product',
+    icon: 'solar:document-text-bold-duotone',
+    docs: [
+      { id: 'features-guide', name: 'KStoryBridge Features', path: 'docs/KStoryBridge_features.md' },
+      { id: 'stripe-integration', name: 'Stripe Integration', path: 'docs/STRIPE_PAYMENT_INTEGRATION.md' },
+      { id: 'stripe-config', name: 'Stripe Configuration', path: 'docs/STRIPE_CONFIGURATION_REFERENCE.md' },
+      { id: 'migration-policy', name: 'Migration Policy', path: 'docs/MIGRATION_POLICY.md' },
+      { id: 'webhook-setup', name: 'Webhook Setup', path: 'docs/WEBHOOK_SETUP_CHECKLIST.md' },
+    ],
+  },
+  {
+    id: 'scripts',
+    name: 'Scripts',
+    icon: 'solar:code-bold-duotone',
+    docs: [
+      { id: 'scripts-readme', name: 'Scripts Overview', path: 'scripts/README.md' },
+      {
+        id: 'scripts-reference',
+        name: 'Scripts Reference',
+        path: '',
+        inlineContent: `# Scripts Reference
+
+This document provides a quick reference for all utility scripts in the \`/scripts\` directory.
+
+---
+
+## Deployment & Build Scripts
+
+| Script | Description |
+|--------|-------------|
+| \`vercel-ignore-turbo.sh\` | Selective deployment script for Vercel. Determines which apps need rebuilding based on changes. Used in Vercel's "Ignored Build Step" setting. |
+| \`check-app-changes.sh\` | Checks if specific app directories have changed since last deployment. |
+
+---
+
+## Database & Data Scripts
+
+### Keyword Extraction
+| Script | Description |
+|--------|-------------|
+| \`keyword-extractor.js\` | Main keyword extraction script. Extracts meaningful keywords from titles for content discovery. |
+| \`generate-keyword-updates.js\` | Generates SQL update statements from keyword extraction results. |
+| \`update-keywords.sql\` | SQL script to update keywords in the titles table. |
+| \`update-keywords-complete.sql\` | Complete SQL script with all keyword updates. |
+
+### Comp Analysis
+| Script | Description |
+|--------|-------------|
+| \`comp-identifier.js\` | Main comparable title identification engine. Calculates similarity scores across multiple dimensions. |
+| \`generate-comp-report.js\` | Generates human-readable markdown reports from comp analysis. |
+| \`visual-comp-identifier.js\` | Visual comparison tool for identifying similar titles. |
+
+### Embeddings & Vector Search
+| Script | Description |
+|--------|-------------|
+| \`regenerate-embeddings.js\` | Regenerates vector embeddings for titles using OpenAI API. |
+| \`regenerate-specific-title.js\` | Regenerates embedding for a specific title by ID. |
+| \`fix-doting-father-embedding.js\` | Fixes embedding issues for specific title. |
+| \`count-valid-embeddings.js\` | Counts titles with valid embeddings in the database. |
+| \`verify-regeneration-success.js\` | Verifies that embedding regeneration completed successfully. |
+| \`test-openai-embedding.js\` | Tests OpenAI embedding API connection and functionality. |
+| \`test-write-read-embedding.js\` | Tests writing and reading embeddings to/from database. |
+
+### Cache Management
+| Script | Description |
+|--------|-------------|
+| \`check-comp-cache.js\` | Checks the state of the comp title cache. |
+| \`clear-comp-cache.sql\` | SQL to clear the comp title cache table. |
+| \`warm-comp-title-cache.js\` | Pre-warms the comp title cache with common searches. |
+| \`test-cache-after-search.js\` | Tests cache behavior after performing searches. |
+
+### User & Data Verification
+| Script | Description |
+|--------|-------------|
+| \`check-user-buyer.js\` | Checks user_buyers table for specific user data. |
+| \`verify-database-state.sql\` | SQL queries to verify database state and data integrity. |
+| \`cleanup-duplicate-messages.sql\` | Cleans up duplicate chat messages in the database. |
+
+---
+
+## Testing Scripts
+
+### Edge Function Testing
+| Script | Description |
+|--------|-------------|
+| \`test-function-health.js\` | Tests health of all deployed edge functions. |
+| \`test-edge-functions.ts\` | Comprehensive edge function testing suite. |
+| \`test-validation-only.js\` | Tests input validation for edge functions. |
+| \`test-security-fixes.js\` | Tests security fixes and vulnerability patches. |
+
+### Feature Testing
+| Script | Description |
+|--------|-------------|
+| \`test-generate-asset.js\` | Tests the asset generation edge function. |
+| \`test-analyze-pitch-assets.js\` | Tests pitch deck asset analysis. |
+| \`test-marketing-assets-setup.js\` | Tests marketing assets setup and configuration. |
+| \`test-checkout-uuid-fix.ts\` | Tests checkout UUID fix for Stripe integration. |
+
+### Search Testing
+| Script | Description |
+|--------|-------------|
+| \`test-horror-search.js\` | Tests vector search with horror genre queries. |
+| \`test-this-is-us-search.js\` | Tests search functionality with "This Is Us" title. |
+| \`test-vector-search-this-is-us.js\` | Tests vector search specifically for "This Is Us". |
+| \`test-mandate-search.js\` | Tests mandate matching search functionality. |
+| \`test-comps-exact-dashboard.js\` | Tests comps functionality as used in dashboard. |
+| \`check-horror-titles-similarity.js\` | Checks similarity scores for horror titles. |
+
+### Scraping Testing
+| Script | Description |
+|--------|-------------|
+| \`test-naver-scraper.ts\` | Tests Naver webtoon/series scraping functionality. |
+| \`scrape_webtoons.py\` | Python script for scraping webtoon data. |
+
+---
+
+## Storage & Asset Scripts
+
+| Script | Description |
+|--------|-------------|
+| \`create-storage-bucket.js\` | Creates Supabase storage buckets for assets. |
+| \`make-bucket-public.js\` | Makes a storage bucket publicly accessible. |
+| \`diagnose-asset.js\` | Diagnoses issues with asset storage and retrieval. |
+
+---
+
+## Import & Migration Scripts
+
+| Script | Description |
+|--------|-------------|
+| \`fix-imports.js\` | Fixes import statements across the codebase. |
+| \`fix-all-imports.js\` | Comprehensive import fixing script. |
+| \`nuclear-import-fix.js\` | Aggressive import fixing for stubborn issues. |
+| \`update-imports.js\` | Updates import paths after refactoring. |
+| \`extract_mock_data.js\` | Extracts mock data for testing purposes. |
+
+---
+
+## Webhook & Integration Scripts
+
+| Script | Description |
+|--------|-------------|
+| \`verify-stripe-webhook.sh\` | Verifies Stripe webhook configuration and connectivity. |
+| \`debug-subscription-issue.sql\` | SQL queries for debugging subscription issues. |
+
+---
+
+## Data Analysis Scripts
+
+| Script | Description |
+|--------|-------------|
+| \`check-doting-father.js\` | Analyzes data for "Doting Father" title specifically. |
+| \`test-parse-embedding.js\` | Tests parsing of embedding data. |
+| \`verify-optimization.js\` | Verifies optimization improvements. |
+| \`batch-format-fit-analysis.js\` | Batch analysis for format fit scoring. |
+
+---
+
+## Usage
+
+Most scripts can be run with Node.js:
+
+\`\`\`bash
+cd scripts
+npm install  # Install dependencies (first time only)
+node <script-name>.js
+\`\`\`
+
+For TypeScript scripts:
+\`\`\`bash
+npx ts-node <script-name>.ts
+\`\`\`
+
+For shell scripts:
+\`\`\`bash
+chmod +x <script-name>.sh
+./<script-name>.sh
+\`\`\`
+
+---
+
+## Environment Variables
+
+Many scripts require environment variables. Create a \`.env\` file in the scripts directory or set them in your shell:
+
+\`\`\`bash
+SUPABASE_URL=https://dlrnrgcoguxlkkcitlpd.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=<your-service-role-key>
+OPENAI_API_KEY=<your-openai-api-key>
+\`\`\`
+
+---
+
+*Last updated: December 2024*
+`
+      },
+    ],
+  },
+];
+
+// GitHub raw URL base for fetching docs
+const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/creepyblues/kstorybridge-integrated/main/';
+
+export default function AdminDocs() {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedDoc, setSelectedDoc] = useState<DocItem | null>(null);
+  const [docContents, setDocContents] = useState<Record<string, { content?: string; loading?: boolean; error?: boolean }>>({});
+  const [expandedCategories, setExpandedCategories] = useState<string[]>(['core']);
+
+  // Calculate total docs
+  const totalDocs = DOC_CATEGORIES.reduce((sum, cat) => sum + cat.docs.length, 0);
+
+  // Filter docs based on search (only filters by name since content isn't loaded yet)
+  const filteredCategories = useMemo(() => {
+    if (!searchQuery.trim()) return DOC_CATEGORIES;
+
+    const query = searchQuery.toLowerCase();
+    return DOC_CATEGORIES
+      .map(category => ({
+        ...category,
+        docs: category.docs.filter(doc =>
+          doc.name.toLowerCase().includes(query)
+        ),
+      }))
+      .filter(category => category.docs.length > 0);
+  }, [searchQuery]);
+
+  // Set default doc on mount
+  useEffect(() => {
+    if (!selectedDoc && DOC_CATEGORIES[0]?.docs[0]) {
+      handleDocSelect(DOC_CATEGORIES[0].docs[0]);
+    }
+  }, []);
+
+  const fetchDocContent = async (doc: DocItem) => {
+    if (docContents[doc.id]?.content || docContents[doc.id]?.loading) {
+      return;
+    }
+
+    // Handle inline content (no fetch needed)
+    if (doc.inlineContent) {
+      setDocContents(prev => ({
+        ...prev,
+        [doc.id]: { content: doc.inlineContent, loading: false },
+      }));
+      return;
+    }
+
+    setDocContents(prev => ({
+      ...prev,
+      [doc.id]: { loading: true },
+    }));
+
+    try {
+      const response = await fetch(`${GITHUB_RAW_BASE}${doc.path}`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch: ${response.status}`);
+      }
+      const content = await response.text();
+      setDocContents(prev => ({
+        ...prev,
+        [doc.id]: { content, loading: false },
+      }));
+    } catch (error) {
+      console.error(`Error fetching ${doc.path}:`, error);
+      setDocContents(prev => ({
+        ...prev,
+        [doc.id]: { error: true, loading: false },
+      }));
+    }
+  };
+
+  const handleDocSelect = (doc: DocItem) => {
+    setSelectedDoc(doc);
+    fetchDocContent(doc);
+  };
+
+  const getCurrentDocContent = () => {
+    if (!selectedDoc) return null;
+    return docContents[selectedDoc.id];
+  };
+
+  const docState = getCurrentDocContent();
+
+  return (
+    <div className="h-screen flex flex-col bg-gray-50">
+      {/* Header */}
+      <div className="border-b bg-white p-4 shadow-sm">
+        <div className="flex items-center gap-4">
+          <Link
+            to="/admin"
+            className="p-2 rounded-lg hover:bg-gray-100 transition-colors"
+            title="Back to Admin"
+          >
+            <Icon icon="solar:arrow-left-linear" className="h-5 w-5 text-gray-600" />
+          </Link>
+          <div className="flex items-center gap-2">
+            <Icon icon="solar:notebook-bold-duotone" className="h-6 w-6 text-hanok-teal" />
+            <h1 className="text-xl font-semibold">Documentation</h1>
+          </div>
+          <div className="flex-1 max-w-md">
+            <div className="relative">
+              <Icon
+                icon="solar:magnifer-linear"
+                className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400"
+              />
+              <Input
+                placeholder="Search documentation..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-9"
+              />
+            </div>
+          </div>
+          <span className="text-sm text-gray-500">
+            {totalDocs} documents
+          </span>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <div className="flex-1 flex overflow-hidden">
+        {/* Sidebar */}
+        <div className="w-72 border-r bg-white overflow-y-auto shadow-sm">
+          <Accordion
+            type="multiple"
+            value={expandedCategories}
+            onValueChange={setExpandedCategories}
+            className="p-2"
+          >
+            {filteredCategories.map(category => (
+              <AccordionItem
+                key={category.id}
+                value={category.id}
+                className="border-none"
+              >
+                <AccordionTrigger className="hover:no-underline py-2 px-3 rounded-lg hover:bg-gray-100">
+                  <div className="flex items-center gap-2">
+                    <Icon icon={category.icon} className="h-4 w-4 text-gray-600" />
+                    <span className="font-medium text-sm">{category.name}</span>
+                    <span className="text-xs text-gray-400 ml-auto mr-2">
+                      {category.docs.length}
+                    </span>
+                  </div>
+                </AccordionTrigger>
+                <AccordionContent className="pb-2">
+                  <div className="space-y-0.5 pl-6">
+                    {category.docs.map(doc => (
+                      <button
+                        key={doc.id}
+                        onClick={() => handleDocSelect(doc)}
+                        className={cn(
+                          'w-full text-left px-3 py-1.5 rounded-md text-sm transition-colors',
+                          selectedDoc?.id === doc.id
+                            ? 'bg-hanok-teal text-white'
+                            : 'text-gray-700 hover:bg-gray-100'
+                        )}
+                      >
+                        {doc.name}
+                      </button>
+                    ))}
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+
+          {filteredCategories.length === 0 && (
+            <div className="p-4 text-center text-gray-500 text-sm">
+              No documents match your search
+            </div>
+          )}
+        </div>
+
+        {/* Content Area */}
+        <div className="flex-1 overflow-y-auto bg-white">
+          {selectedDoc ? (
+            <Card className="m-4 border-0 shadow-none">
+              <CardContent className="prose prose-sm max-w-none p-6">
+                {docState?.loading && (
+                  <div className="flex items-center justify-center py-12">
+                    <Icon icon="solar:spinner-bold" className="h-8 w-8 animate-spin text-hanok-teal" />
+                    <span className="ml-2 text-gray-500">Loading documentation...</span>
+                  </div>
+                )}
+                {docState?.error && (
+                  <div className="text-center py-12">
+                    <Icon icon="solar:danger-triangle-bold-duotone" className="h-12 w-12 mx-auto mb-4 text-red-400" />
+                    <h2 className="text-lg font-semibold text-gray-900 mb-2">Failed to Load Document</h2>
+                    <p className="text-gray-500 mb-4">
+                      Could not load <code className="bg-gray-100 px-2 py-1 rounded">{selectedDoc.path}</code>
+                    </p>
+                    <button
+                      onClick={() => fetchDocContent(selectedDoc)}
+                      className="px-4 py-2 bg-hanok-teal text-white rounded-lg hover:bg-hanok-teal/90 transition-colors"
+                    >
+                      Retry
+                    </button>
+                  </div>
+                )}
+                {docState?.content && (
+                  <ReactMarkdown
+                    remarkPlugins={[remarkGfm]}
+                    components={{
+                      // Custom styling for headers
+                      h1: ({ children }) => (
+                        <h1 className="text-2xl font-bold text-gray-900 border-b pb-2 mb-4">{children}</h1>
+                      ),
+                      h2: ({ children }) => (
+                        <h2 className="text-xl font-semibold text-gray-800 mt-6 mb-3">{children}</h2>
+                      ),
+                      h3: ({ children }) => (
+                        <h3 className="text-lg font-medium text-gray-700 mt-4 mb-2">{children}</h3>
+                      ),
+                      // Code blocks
+                      code: ({ className, children, ...props }) => {
+                        const isInline = !className;
+                        if (isInline) {
+                          return (
+                            <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm font-mono text-hanok-teal" {...props}>
+                              {children}
+                            </code>
+                          );
+                        }
+                        return (
+                          <code className={cn("block bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto text-sm", className)} {...props}>
+                            {children}
+                          </code>
+                        );
+                      },
+                      pre: ({ children }) => (
+                        <pre className="bg-gray-900 rounded-lg overflow-x-auto my-4">{children}</pre>
+                      ),
+                      // Tables
+                      table: ({ children }) => (
+                        <div className="overflow-x-auto my-4">
+                          <table className="min-w-full divide-y divide-gray-200 border border-gray-200 rounded-lg">
+                            {children}
+                          </table>
+                        </div>
+                      ),
+                      th: ({ children }) => (
+                        <th className="px-4 py-2 bg-gray-50 text-left text-sm font-semibold text-gray-700">
+                          {children}
+                        </th>
+                      ),
+                      td: ({ children }) => (
+                        <td className="px-4 py-2 text-sm text-gray-600 border-t border-gray-100">
+                          {children}
+                        </td>
+                      ),
+                      // Links
+                      a: ({ href, children }) => (
+                        <a
+                          href={href}
+                          className="text-hanok-teal hover:text-hanok-teal/80 underline"
+                          target={href?.startsWith('http') ? '_blank' : undefined}
+                          rel={href?.startsWith('http') ? 'noopener noreferrer' : undefined}
+                        >
+                          {children}
+                        </a>
+                      ),
+                      // Lists
+                      ul: ({ children }) => (
+                        <ul className="list-disc list-inside space-y-1 my-2">{children}</ul>
+                      ),
+                      ol: ({ children }) => (
+                        <ol className="list-decimal list-inside space-y-1 my-2">{children}</ol>
+                      ),
+                      // Blockquotes
+                      blockquote: ({ children }) => (
+                        <blockquote className="border-l-4 border-hanok-teal pl-4 italic text-gray-600 my-4">
+                          {children}
+                        </blockquote>
+                      ),
+                    }}
+                  >
+                    {docState.content}
+                  </ReactMarkdown>
+                )}
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="flex items-center justify-center h-full text-gray-500">
+              <div className="text-center">
+                <Icon icon="solar:document-text-bold-duotone" className="h-12 w-12 mx-auto mb-2 opacity-30" />
+                <p>Select a document to view</p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,6 +1,6 @@
 # Documentation Index
 
-**Last Updated**: 2025-11-21
+**Last Updated**: 2025-12-17
 
 This is the master index of all active documentation for the KStoryBridge project.
 
@@ -68,12 +68,25 @@ Multi-platform scraping tool for collecting metadata and popularity signals:
 | Document | Description |
 |----------|-------------|
 | **[OPTIMIZATION_COMPLETE.md](features/comps-navigator/OPTIMIZATION_COMPLETE.md)** | ⭐ Complete optimization documentation (95-98% faster) |
+| **[COMPS_NAVIGATOR_SAMPLES.md](features/COMPS_NAVIGATOR_SAMPLES.md)** | ⭐ 37 comp combinations + 35 mandate samples (2025-12-17) |
 | **[COMPS_NAVIGATOR_PLAN.md](features/COMPS_NAVIGATOR_PLAN.md)** | Original feature plan and architecture |
 | **[COMPS_NAVIGATOR_EMBEDDING_FIX.md](COMPS_NAVIGATOR_EMBEDDING_FIX.md)** | Embedding null safety review |
 | **[COMPS_NAVIGATOR_OPTIMIZATION_SUMMARY.md](COMPS_NAVIGATOR_OPTIMIZATION_SUMMARY.md)** | Phase 1 optimization summary |
 | **[COMPS_NAVIGATOR_PHASE2_OPTIMIZATION.md](COMPS_NAVIGATOR_PHASE2_OPTIMIZATION.md)** | Phase 2 optimization summary |
 
 **Related**: [COMPS_NAVIGATOR_USER_GUIDE.md](../apps/dashboard/public/docs/COMPS_NAVIGATOR_USER_GUIDE.md) (user-facing)
+
+### Format Fit Analyzer (`docs/features/`)
+
+| Document | Description |
+|----------|-------------|
+| **[FORMAT_FIT.md](features/FORMAT_FIT.md)** | ⭐ Complete Format Fit documentation (2025-12-16) |
+
+AI-powered format fit analysis for 5 content formats:
+- Film, TV Series, Animation, Microdrama, Audio Drama
+- GPT-4o story deconstruction and scoring
+- Discover Titles format filtering (score ≥ 50)
+- Admin integration via TitleEditModal
 
 ---
 

--- a/docs/features/COMPS_NAVIGATOR_SAMPLES.md
+++ b/docs/features/COMPS_NAVIGATOR_SAMPLES.md
@@ -1,0 +1,284 @@
+# Comps Navigator Sample Data
+
+**Last Updated**: 2025-12-17
+**Purpose**: Curated comp title combinations and mandate samples for the Comps Navigator feature
+**Database Analyzed**: 244 Korean titles (webtoons/webnovels)
+
+---
+
+## Overview
+
+This document provides **37 comp title combinations** and **35 mandate samples** optimized to return strong search results from the KStoryBridge title database. These samples are designed for:
+
+1. **Demo purposes** - Showcasing the Navigator's capabilities to potential buyers
+2. **User onboarding** - Teaching users effective search strategies
+3. **UI examples** - Pre-populated suggestions in the interface
+4. **Testing** - Validating search quality and relevance
+
+---
+
+## Database Composition
+
+| Category | Title Count | Strength |
+|----------|-------------|----------|
+| Romance/Romantasy | 85+ | Very Strong |
+| BL/LGBTQ+ | 40+ | Very Strong |
+| Fantasy/Supernatural | 29+ | Strong |
+| Drama | 30+ | Strong |
+| Comedy/Slice of Life | 15+ | Moderate |
+| Thriller/Horror | 14+ | Moderate |
+| K-pop/Idol | 12+ | Moderate |
+| Historical/Period | 9+ | Moderate |
+| Isekai/Reincarnation | 8+ | Niche |
+
+**Top Tones**: Exciting (50), Romantic (47), Intense (19), Funny (17), Quirky (15), Suspenseful (13)
+
+---
+
+## Comp Title Combinations (37 Total)
+
+### Romance & Romantasy (10 comps)
+
+| ID | Comp Combination | Target Content | Expected Matches |
+|----|------------------|----------------|------------------|
+| R1 | **Outlander + Bridgerton** | Period romance with forbidden love, noble intrigue | Under the Oak Tree, Bongchon Bride, Finding Camellia |
+| R2 | **Twilight + A Court of Thorns and Roses** | Supernatural fantasy romance with dangerous love interests | Werewolves Going Crazy Over Me, Luna, Devil Number 4 |
+| R3 | **Pride and Prejudice + The Princess Diaries** | Hidden identity romance with aristocratic setting | Disobey the Duke if You Dare, The Accidental Heiress |
+| R4 | **The Notebook + A Walk to Remember** | Emotional, tear-jerker romance | Love&Wish, We Are Everyday, Crush on You |
+| R5 | **Mean Girls + To All the Boys I've Loved Before** | High school romance with social dynamics | Shadowy Beauty, Like You've Never Been Hurt |
+| R6 | **How to Lose a Guy in 10 Days + 10 Things I Hate About You** | Fake dating / contract romance rom-com | 4 Week Lovers, Love Lies, Lies Become You |
+| R7 | **Beauty and the Beast + Shrek** | Monster/outcast romance with transformation | Hang byun sin, Who am I, Lady Devil |
+| R8 | **Fifty Shades of Grey + Secretary** | Intense, passionate adult romance | The Cellist, The Odd One Next Door |
+| R9 | **The Time Traveler's Wife + About Time** | Time travel romance with fate themes | Boy From the Future, Cheolsu Saves the World |
+| R10 | **Cinderella + Pretty Woman** | Rags-to-riches romance transformation | Finding Camellia, Beauty Maker |
+
+### BL/LGBTQ+ (5 comps)
+
+| ID | Comp Combination | Target Content | Expected Matches |
+|----|------------------|----------------|------------------|
+| BL1 | **Heartstopper + Love, Simon** | Sweet coming-of-age queer romance | Flip Turn, Shoot for the Stars, spring and winter |
+| BL2 | **Call Me By Your Name + Brokeback Mountain** | Intense, emotional forbidden BL | Young Blood, Throughout the winter, Zero probability |
+| BL3 | **Red, White & Royal Blue + The Prince and the Pauper** | Royal/status-gap BL romance | Stigmata, The Fallen Duke & the Knight |
+| BL4 | **Bros + Fire Island** | Fun, modern comedy BL | Miss You, Lucifer, 4 Week Lovers, Opposites Attract |
+| BL5 | **Portrait of a Lady on Fire + Carol** | Slow-burn, artistic GL romance | spring and winter |
+
+### Fantasy & Supernatural (7 comps)
+
+| ID | Comp Combination | Target Content | Expected Matches |
+|----|------------------|----------------|------------------|
+| F1 | **Game of Thrones + The Witcher** | Epic fantasy with political intrigue | Isnelda, The Flower of Veneration, Mokrin |
+| F2 | **The Conjuring + The Exorcist** | Korean supernatural horror/exorcism | Mayago, Demoniac, The Possession |
+| F3 | **Her + Ex Machina** | Sci-fi romance with AI/technology | Phone Addict, Whispers Through the Willows |
+| F4 | **My Hero Academia + Spider-Man** | Superhero origin with school setting | Girl Hero, Hood, The Superheroes of Class F |
+| F5 | **Spirited Away + Howl's Moving Castle** | Whimsical supernatural with transformation | Hello, Goblin, Cross the universe nine times |
+| F6 | **Train to Busan + World War Z** | Zombie survival thriller | Dealing The Dead, Dead Life |
+| F7 | **Constantine + The Exorcist** | Demonic possession with detective element | Demoniac, Mayago, Cowardly physical |
+
+### K-pop & Celebrity (4 comps)
+
+| ID | Comp Combination | Target Content | Expected Matches |
+|----|------------------|----------------|------------------|
+| K1 | **A Star is Born + La La Land** | Entertainment industry romance | Miss You, Lucifer, My Second Life as an Idol |
+| K2 | **BTS: Yet to Come + One Direction Documentary** | K-pop idol behind-the-scenes | Idol House, Shoot for the Stars, Wild Idols |
+| K3 | **The Devil Wears Prada + Notting Hill** | Celebrity/commoner romance gap | Authority Of The Operator, Pervert For Me |
+| K4 | **Almost Famous + High Fidelity** | Music industry coming-of-age | Noise Comeback, Chosun SUPER Idol |
+
+### Thriller & Mystery (4 comps)
+
+| ID | Comp Combination | Target Content | Expected Matches |
+|----|------------------|----------------|------------------|
+| T1 | **Gone Girl + Fatal Attraction** | Psychological thriller with twisted relationships | Dangerous Cohabitation, Even If... |
+| T2 | **Get Out + Midsommar** | Social horror with cult/isolation themes | Lily House, Crying Rabbit |
+| T3 | **Knives Out + Clue** | Murder mystery with ensemble cast | Boy From the Future, [ blank。] |
+| T4 | **Black Swan + Whiplash** | Obsession and toxic mentor relationships | human market, The Cellist |
+
+### Isekai & Reincarnation (4 comps)
+
+| ID | Comp Combination | Target Content | Expected Matches |
+|----|------------------|----------------|------------------|
+| I1 | **Groundhog Day + Edge of Tomorrow** | Time loop / second chance stories | Stigmata, NPCs Can Save the World Too! |
+| I2 | **Ready Player One + Jumanji** | Game world / isekai adventure | Terrarium Adventure, NPCs Can Save the World Too! |
+| I3 | **The Princess Bride + Stardust** | Fairy tale adventure romance | I Raised a Black Dragon, I've Become a True Villainess |
+| I4 | **Maleficent + Wicked** | Villainess redemption / misunderstood antagonist | I've Become a True Villainess, My Father is a Tyrant |
+
+### Comedy & Slice of Life (3 comps)
+
+| ID | Comp Combination | Target Content | Expected Matches |
+|----|------------------|----------------|------------------|
+| C1 | **Reply 1988 + Gilmore Girls** | Nostalgic family/neighborhood comedy | Wooeng season5, Cat Cap, Day Say Hey |
+| C2 | **Marley & Me + A Dog's Purpose** | Pet companion heartwarming stories | I Am Pet, Cat Cap |
+| C3 | **Bridesmaids + The Hangover** | Chaotic comedy with ensemble cast | Boogie Movie, Udangtangtang Ttasiki |
+
+---
+
+## Mandate Samples (35 Total)
+
+### Streaming Platform Mandates (5)
+
+| ID | Mandate | Target Genre |
+|----|---------|--------------|
+| SP1 | "Looking for **fantasy romance with strong female leads** in aristocratic settings. Prefer completed series with 50+ episodes. For Netflix adaptation." | Romantasy |
+| SP2 | "Seeking **BL romance suitable for mainstream adaptation**. Sweet tone preferred, college or workplace setting. Target: younger millennial audience." | BL/LGBTQ+ |
+| SP3 | "Need **supernatural thriller with Korean mythology** (shamanism, exorcism, mountain spirits). Limited series format, 8-10 episodes." | Horror/Supernatural |
+| SP4 | "**K-pop industry romance or drama** with behind-the-scenes idol life. Comedic tone acceptable. For youth-targeted streaming." | Idol/Celebrity |
+| SP5 | "**Zombie apocalypse with character-driven survival**. Looking for fresh take on genre. Film or limited series." | Thriller/Horror |
+
+### Broadcast Network Mandates (5)
+
+| ID | Mandate | Target Genre |
+|----|---------|--------------|
+| BN1 | "**Heartwarming family comedy** with multi-generational cast. Episodic format, suitable for primetime broadcast." | Slice of Life |
+| BN2 | "**High school romance** with relatable teen protagonists. Coming-of-age themes, nothing too mature." | School Romance |
+| BN3 | "**Period drama romance** set in Joseon era or fantasy historical setting. Epic scope, 16+ episodes." | Historical/Period |
+| BN4 | "**Romantic comedy with contract/fake relationship** premise. Light tone, happy ending required." | Rom-Com |
+| BN5 | "**Medical or legal drama with romantic subplot**. Strong ensemble cast potential." | Drama |
+
+### Film Studio Mandates (5)
+
+| ID | Mandate | Target Genre |
+|----|---------|--------------|
+| FS1 | "**Time travel romance** with mystery elements. Feature film potential, emotional payoff required." | Sci-Fi Romance |
+| FS2 | "**Horror film with possession/exorcism** themes. Korean shamanism angle preferred." | Horror |
+| FS3 | "**Romantic drama with tragic elements**. Oscar-bait potential, literary quality." | Drama Romance |
+| FS4 | "**Action fantasy with superhero elements**. Origin story format, franchise potential." | Fantasy Action |
+| FS5 | "**Psychological thriller** with unreliable narrator. Twist ending, contained cast." | Thriller |
+
+### International Adaptation Mandates (5)
+
+| ID | Mandate | Target Genre |
+|----|---------|--------------|
+| IA1 | "Looking for **villainess/isekai romance** that could adapt to Western fantasy setting." | Isekai/Romantasy |
+| IA2 | "**LGBTQ+ content with crossover appeal**. Must work for both Asian and Western markets." | LGBTQ+ |
+| IA3 | "**Celebrity romance** that translates across cultures. Entertainment industry setting." | Celebrity Romance |
+| IA4 | "**Supernatural romance** similar to Twilight franchise. YA audience, series potential." | Supernatural |
+| IA5 | "**Slice-of-life comedy** with universal themes. Low-budget adaptation friendly." | Comedy |
+
+### Genre-Specific Mandates (5)
+
+| ID | Mandate | Target Genre |
+|----|---------|--------------|
+| GS1 | "**Enemies-to-lovers fantasy romance** with magical elements. Strong chemistry required." | Fantasy Romance |
+| GS2 | "**Revenge thriller** with female protagonist. Dark tone, satisfying payoff." | Thriller |
+| GS3 | "**Cohabitation romance comedy**. Forced proximity trope, modern setting." | Rom-Com |
+| GS4 | "**Gothic romance** with dark supernatural elements. Atmospheric, moody tone." | Gothic Romance |
+| GS5 | "**Sports or competition-based romance**. Underdog story, inspirational arc." | Sports Romance |
+
+### Demographic-Specific Mandates (5)
+
+| ID | Mandate | Target Genre |
+|----|---------|--------------|
+| DS1 | "Content for **female 18-34 demographic**. Romance-forward, aspirational lifestyle elements." | Romance |
+| DS2 | "**Male-skewing action fantasy** with romance subplot. Not primarily romance." | Action Fantasy |
+| DS3 | "**Teen/YA content** with first love themes. Clean romance, school setting." | YA Romance |
+| DS4 | "**Mature romance** for 25+ audience. Complex relationships, adult situations okay." | Adult Romance |
+| DS5 | "**Family-friendly fantasy** suitable for co-viewing. Adventure with heart." | Family Fantasy |
+
+### Format-Specific Mandates (5)
+
+| ID | Mandate | Target Genre |
+|----|---------|--------------|
+| FM1 | "**Webtoon-to-drama adaptation** with strong visual storytelling. Established fanbase preferred." | Various |
+| FM2 | "**Short-form content** (under 10 min episodes). Snackable romance or comedy." | Short-Form |
+| FM3 | "**Anthology series potential** - connected stories or standalone episodes." | Anthology |
+| FM4 | "**Animation-friendly IP** with distinctive visual style and fantastical elements." | Animation |
+| FM5 | "**Live-action remake potential** for existing animated/webtoon property." | Adaptation |
+
+---
+
+## Usage Guidelines
+
+### For Demo Purposes
+
+**Best comp combinations for live demos:**
+1. **R2** (Twilight + ACOTAR) - Returns visually striking supernatural romance
+2. **BL1** (Heartstopper + Love, Simon) - Shows LGBTQ+ content breadth
+3. **F2** (Conjuring + Exorcist) - Demonstrates Korean horror niche
+4. **K1** (A Star is Born + La La Land) - Highlights K-pop/idol content
+
+### For UI Implementation
+
+**Suggested example slots by category:**
+```typescript
+const FEATURED_EXAMPLES = [
+  { comps: ['Twilight', 'A Court of Thorns and Roses'], label: 'Supernatural Romance' },
+  { comps: ['Heartstopper', 'Love, Simon'], label: 'LGBTQ+ Romance' },
+  { comps: ['The Conjuring', 'The Exorcist'], label: 'Korean Horror' },
+  { comps: ['Outlander', 'Bridgerton'], label: 'Period Romance' },
+  { comps: ['Train to Busan', 'World War Z'], label: 'Zombie Thriller' },
+];
+```
+
+### Expected Match Counts
+
+Each comp combination is designed to return **3-8 relevant matches**, demonstrating value without overwhelming users:
+
+| Match Count | User Experience |
+|-------------|-----------------|
+| 1-2 | Too narrow - may feel limited |
+| 3-5 | Optimal - focused, high relevance |
+| 6-8 | Good - variety with relevance |
+| 9+ | May dilute relevance perception |
+
+---
+
+## Maintenance Notes
+
+### When to Update
+
+- **Add new comps** when 10+ new titles are added to a genre
+- **Remove comps** if expected matches drop below 2
+- **Adjust mandates** based on actual buyer inquiry patterns
+
+### Testing Checklist
+
+- [ ] Each comp combination returns 3+ matches
+- [ ] No comp returns 0 matches
+- [ ] Mandate keywords align with title synopses
+- [ ] Examples cover all major database genres
+
+---
+
+## Related Documentation
+
+- [Comps Navigator Overview](../features/chatbot/OVERVIEW.md)
+- [Dashboard CLAUDE.md](../../apps/dashboard/CLAUDE.md) - Comps Navigator section
+- [Database Schema](../active/DATABASE_SCHEMA.md) - titles table structure
+
+---
+
+## Appendix: Title Examples by Category
+
+### Top Romance Titles
+- Under the Oak Tree (상수리 나무 아래)
+- Crush on You (재밌니, 짝사랑)
+- Love&Wish (러브 앤 위시)
+- Finding Camellia
+- Disobey the Duke if You Dare
+
+### Top BL/LGBTQ+ Titles
+- 4 Week Lovers
+- Flip Turn
+- Miss You, Lucifer
+- Traces of the Sun
+- Stigmata
+
+### Top Fantasy Titles
+- I Raised a Black Dragon (흑막용을 키우게 되었다)
+- Luna (루나)
+- Phone Addict (스마트폰 중독자)
+- Hello, Goblin (안녕 도깨비)
+- Devil Number 4 (악마와 계약연애)
+
+### Top Thriller Titles
+- Mayago (마야고)
+- The Dilettante
+- Dangerous Cohabitation (위험한 동거)
+- The Possession (빙의)
+- Crying Rabbit (토끼는 숨죽여 울고 있었다)
+
+### Top Idol/Celebrity Titles
+- Idol House (우리집 아이돌)
+- Miss You, Lucifer
+- My Second Life as an Idol
+- Authority Of The Operator (운영자의 권한으로)
+- Shoot for the Stars


### PR DESCRIPTION
## Summary
- Add `COMPS_NAVIGATOR_SAMPLES.md` with 37 comp title combinations and 35 mandate samples
- Update `docs/INDEX.md` to include new document reference  
- Add "Comps Sample Data" to admin Docs.tsx navigation

## Details
Samples are optimized for the 244 Korean titles in the database, covering:
- Romance & Romantasy (10 comps)
- BL/LGBTQ+ (5 comps)
- Fantasy & Supernatural (7 comps)
- K-pop & Celebrity (4 comps)
- Thriller & Mystery (4 comps)
- Isekai & Reincarnation (4 comps)
- Comedy & Slice of Life (3 comps)

Plus 35 mandate samples across streaming, broadcast, film, and international categories.

## Test plan
- [ ] Verify doc appears in Features section of /admin/docs
- [ ] Verify doc content loads correctly from GitHub raw

🤖 Generated with [Claude Code](https://claude.com/claude-code)