### PR TITLE
fix: Fix race condition in comps suggestion pill click

### DIFF
--- a/apps/dashboard/src/components/comps-navigator/CompsNavigatorInput.tsx
+++ b/apps/dashboard/src/components/comps-navigator/CompsNavigatorInput.tsx
@@ -35,7 +35,7 @@ export default function CompsNavigatorInput({
   onChange,
   onSearch,
   onClear,
-  onNeedHelp,
+  onNeedHelp: _onNeedHelp, // Reserved for future "Need Help" button
   isLoading,
   loadingPhase,
   searchInfo,
@@ -62,6 +62,29 @@ export default function CompsNavigatorInput({
 
   // Use centralized suggestion data from examplesData.ts
   const exampleSuggestions = useMemo(() => getRandomCompSuggestions(3), []);
+
+  // Handle clicking an example suggestion - parse and execute search directly
+  const handleExampleClick = (example: string) => {
+    // Parse the example (may contain " + " to separate titles)
+    const titles = example.split(' + ').map(title => title.trim());
+
+    // Create CompTitle objects for each title
+    const newCompTitles: CompTitle[] = titles.map(title => ({
+      title,
+      imdbID: '',
+      year: '',
+      type: 'movie' as const,
+    }));
+
+    // Set the comp titles and trigger search
+    onChange(newCompTitles);
+    setActiveInputCount(newCompTitles.length);
+
+    // Use setTimeout to ensure state is updated before search
+    setTimeout(() => {
+      onSearch();
+    }, 0);
+  };
 
   // Sync activeInputCount with compTitles length
   useEffect(() => {
@@ -478,7 +501,7 @@ export default function CompsNavigatorInput({
           {exampleSuggestions.map((example) => (
             <button
               key={example}
-              onClick={onNeedHelp}
+              onClick={() => handleExampleClick(example)}
               disabled={isLoading}
               className="px-2.5 py-1.5 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-full transition-colors disabled:opacity-50"
             >

--- a/apps/dashboard/src/components/comps-navigator/CompsNavigatorInput.tsx
+++ b/apps/dashboard/src/components/comps-navigator/CompsNavigatorInput.tsx
@@ -20,7 +20,7 @@ import { getRandomCompSuggestions } from '@/data/examplesData';
 interface CompsNavigatorInputProps {
   compTitles: CompTitle[];
   onChange: (titles: CompTitle[]) => void;
-  onSearch: () => void;
+  onSearch: (overrideCompTitles?: CompTitle[]) => void;
   onClear: () => void;
   onNeedHelp: () => void;
   isLoading: boolean;
@@ -76,13 +76,13 @@ export default function CompsNavigatorInput({
       type: 'movie' as const,
     }));
 
-    // Set the comp titles and trigger search
+    // Set the comp titles for UI display
     onChange(newCompTitles);
     setActiveInputCount(newCompTitles.length);
 
-    // Use setTimeout to ensure state is updated before search
+    // Pass titles directly to onSearch to avoid race condition with state update
     setTimeout(() => {
-      onSearch();
+      onSearch(newCompTitles);
     }, 0);
   };
 
@@ -476,7 +476,7 @@ export default function CompsNavigatorInput({
           </Button>
         )}
         <Button
-          onClick={onSearch}
+          onClick={() => onSearch()}
           disabled={isLoading || compTitles.length === 0}
           className="bg-gradient-to-r from-hanok-teal to-cyan-600 hover:from-hanok-teal/90 hover:to-cyan-700"
         >

--- a/apps/dashboard/src/components/trial/TrialCompsSection.tsx
+++ b/apps/dashboard/src/components/trial/TrialCompsSection.tsx
@@ -58,8 +58,11 @@ export function TrialCompsSection() {
     }
   }, [searchParams, setSearchParams]);
 
-  const handleSearch = async () => {
-    if (compTitles.length === 0) {
+  const handleSearch = async (overrideCompTitles?: CompTitle[]) => {
+    // Use override titles if provided (from suggestion click), otherwise use state
+    const titlesToSearch = overrideCompTitles || compTitles;
+
+    if (titlesToSearch.length === 0) {
       toast({
         title: "No Comps Selected",
         description: "Please add at least one comparable title to search",
@@ -81,7 +84,7 @@ export function TrialCompsSection() {
     try {
       const phaseTimer = setTimeout(() => setLoadingPhase('reranking'), 1500);
 
-      const titleStrings = compTitlesToStrings(compTitles);
+      const titleStrings = compTitlesToStrings(titlesToSearch);
 
       // Call service with saveSearch: false for trial mode
       const response = await compsNavigatorService.searchComps(

--- a/apps/dashboard/src/pages/buyers/CompsNavigator.tsx
+++ b/apps/dashboard/src/pages/buyers/CompsNavigator.tsx
@@ -173,8 +173,11 @@ export default function CompsNavigator() {
     }
   };
 
-  const handleSearch = async () => {
-    if (compTitles.length === 0) {
+  const handleSearch = async (overrideCompTitles?: CompTitle[]) => {
+    // Use override titles if provided (from suggestion click), otherwise use state
+    const titlesToSearch = overrideCompTitles || compTitles;
+
+    if (titlesToSearch.length === 0) {
       toast({
         title: "No Comps Selected",
         description: "Please add at least one comparable title to search",
@@ -183,7 +186,7 @@ export default function CompsNavigator() {
       return;
     }
     // Delegate to handleSearchWithTitles to avoid code duplication
-    await handleSearchWithTitles(compTitlesToStrings(compTitles));
+    await handleSearchWithTitles(compTitlesToStrings(titlesToSearch));
   };
 
   const handleLoadSearch = (search: CompSearch) => {


### PR DESCRIPTION
## Summary
- Fix race condition when clicking suggestion pills (e.g., "Maleficent + Wicked") on Trial and Comps Navigator pages
- Previously showed "No Comps Selected" error because `onSearch()` fired before React state updated
- Solution: Pass comp titles directly to `onSearch()` to bypass stale parent state

## Changes
- `CompsNavigatorInput.tsx`: `onSearch` prop now accepts optional `CompTitle[]` parameter
- `TrialCompsSection.tsx`: `handleSearch` uses override titles if provided
- `CompsNavigator.tsx`: `handleSearch` uses override titles if provided

## Test plan
- [ ] Go to `/trial` page → click suggestion pill → should search without error
- [ ] Go to `/buyers/comps-navigator` → click suggestion pill → should search without error
- [ ] Manual search (typing + clicking Find Matches) should still work
- [ ] "Try This Example" button from examples modal should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)