### PR TITLE
fix: Update Title Approval icon in admin sidebar

### DIFF
--- a/apps/dashboard/src/components/layout/AdminLayout.tsx
+++ b/apps/dashboard/src/components/layout/AdminLayout.tsx
@@ -39,7 +39,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
     {
       name: 'Title Approval',
       href: '/admin/title-approval',
-      icon: 'solar:document-check-bold-duotone',
+      icon: 'solar:clipboard-check-bold-duotone',
       description: 'Review title submissions'
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,8 @@
       "version": "2.0.0",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
+        "@iconify-json/solar": "^1.2.5",
+        "@iconify/react": "^6.0.2",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",


### PR DESCRIPTION
## Summary
- Update Title Approval sidebar icon from `document-check` to `clipboard-check` for better visual distinction
- Add iconify dependencies to package-lock.json

## Changes
- `apps/dashboard/src/components/layout/AdminLayout.tsx` - Icon update

## Test plan
- [ ] Verify admin sidebar displays the new clipboard-check icon correctly
- [ ] Confirm icon renders properly on all screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)