### PR TITLE
fix: Add romantic_foil character roles to fix production build

### DIFF
--- a/apps/dashboard/src/components/admin/CharacterDetailsInput.tsx
+++ b/apps/dashboard/src/components/admin/CharacterDetailsInput.tsx
@@ -16,7 +16,7 @@ import { CharacterDetail } from '@/services/titlesService';
 // Extended type with temp ID for form management
 export interface CharacterFormDetail extends Omit<CharacterDetail, 'role'> {
   id: string;
-  role: 'protagonist' | 'antagonist' | 'supporting' | 'minor' | '';
+  role: 'protagonist' | 'antagonist' | 'supporting' | 'minor' | 'romantic_foil' | 'romantic_false_foil' | '';
 }
 
 interface CharacterDetailsInputProps {
@@ -30,6 +30,8 @@ const ROLE_OPTIONS = [
   { value: 'antagonist', label: 'Antagonist' },
   { value: 'supporting', label: 'Supporting' },
   { value: 'minor', label: 'Minor' },
+  { value: 'romantic_foil', label: 'Romantic Foil' },
+  { value: 'romantic_false_foil', label: 'Romantic False Foil' },
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary
- Fixes TypeScript build error in production deployment
- Adds `romantic_foil` and `romantic_false_foil` to `CharacterFormDetail.role` type to match `CharacterDetail` type
- Adds corresponding UI options to `ROLE_OPTIONS` array

## Problem
Vercel build on `main` branch was failing with:
```
Type '"romantic_foil"' is not assignable to type '"" | "protagonist" | "antagonist" | "supporting" | "minor"'.
```

The `deserializeCharacters()` function maps `CharacterDetail[]` to `CharacterFormDetail[]`, but the narrower role type in `CharacterFormDetail` caused type errors when database data contained `romantic_foil` or `romantic_false_foil` values.

## Test plan
- [ ] Vercel preview build should pass without TypeScript errors
- [ ] Dashboard admin WeeklyTitle page loads correctly
- [ ] Character role dropdown shows all 6 options

🤖 Generated with [Claude Code](https://claude.com/claude-code)