### PR TITLE
Deploy v2 to production: login redirect, pricing, and UI fixes

### DIFF
--- a/apps/creator/src/components/ProtectedRoute.tsx
+++ b/apps/creator/src/components/ProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router-dom'
 import { useAuth } from '@/hooks/useAuth'
 
 interface ProtectedRouteProps {
@@ -7,6 +7,7 @@ interface ProtectedRouteProps {
 
 export default function ProtectedRoute({ children }: ProtectedRouteProps) {
   const { user, loading } = useAuth()
+  const location = useLocation()
 
   if (loading) {
     return (
@@ -20,6 +21,10 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
   }
 
   if (!user) {
+    const intendedPath = location.pathname + location.search
+    if (intendedPath !== '/' && intendedPath !== '/signin') {
+      sessionStorage.setItem('redirect_after_login', intendedPath)
+    }
     return <Navigate to="/signin" replace />
   }
 

--- a/apps/creator/src/pages/auth/AuthCallback.tsx
+++ b/apps/creator/src/pages/auth/AuthCallback.tsx
@@ -155,6 +155,7 @@ export default function AuthCallback() {
 
       if (sessionError || !session) {
         console.error('❌ OAuth session error:', sessionError)
+        sessionStorage.removeItem('redirect_after_login')
         setStatus('Authentication failed. Please try again.')
         setTimeout(() => navigate('/signin'), 3000)
         return
@@ -211,7 +212,9 @@ export default function AuthCallback() {
           }).catch(() => {})
         }
         setStatus('Welcome back! Redirecting...')
-        navigate('/home')
+        const redirectUrl = sessionStorage.getItem('redirect_after_login') || '/home'
+        sessionStorage.removeItem('redirect_after_login')
+        navigate(redirectUrl)
       } else {
         // New user - redirect to profile completion
         console.log('📝 New user, redirecting to profile completion')
@@ -221,6 +224,7 @@ export default function AuthCallback() {
 
     } catch (error: any) {
       console.error('❌ Auth callback error:', error)
+      sessionStorage.removeItem('redirect_after_login')
       setStatus('Authentication failed: ' + error.message)
       setTimeout(() => navigate('/signin'), 3000)
     }

--- a/apps/creator/src/pages/auth/SignIn.tsx
+++ b/apps/creator/src/pages/auth/SignIn.tsx
@@ -71,7 +71,9 @@ export default function SignIn() {
       await signInWithEmail(formData.email, formData.password)
       console.log('✅ Signin successful, redirecting to home')
       trackLogin('email')
-      navigate('/home')
+      const redirectUrl = sessionStorage.getItem('redirect_after_login') || '/home'
+      sessionStorage.removeItem('redirect_after_login')
+      navigate(redirectUrl)
     } catch (err: any) {
       console.error('❌ Signin error:', err)
 

--- a/apps/dashboard/src/components/ProtectedRoute.tsx
+++ b/apps/dashboard/src/components/ProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
 import { Icon } from '@iconify/react';
 
@@ -8,6 +8,7 @@ interface ProtectedRouteProps {
 
 export function ProtectedRoute({ children }: ProtectedRouteProps) {
   const { user, loading } = useAuth();
+  const location = useLocation();
 
   if (loading) {
     return (
@@ -18,6 +19,10 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
   }
 
   if (!user) {
+    const intendedPath = location.pathname + location.search;
+    if (intendedPath !== '/' && intendedPath !== '/signin') {
+      sessionStorage.setItem('redirect_after_login', intendedPath);
+    }
     return <Navigate to="/signin" replace />;
   }
 

--- a/apps/dashboard/src/pages/auth/AuthCallback.tsx
+++ b/apps/dashboard/src/pages/auth/AuthCallback.tsx
@@ -18,6 +18,7 @@ const CALLBACK_TIMEOUT_MS = 15000; // 15 seconds max for entire callback flow
 function clearOAuthStorage() {
   sessionStorage.removeItem('oauth_account_type');
   sessionStorage.removeItem('oauth_flow');
+  sessionStorage.removeItem('redirect_after_login');
 }
 
 export default function AuthCallback() {
@@ -100,7 +101,9 @@ export default function AuthCallback() {
           description: 'Successfully signed in',
           variant: 'success',
         });
-        navigate('/buyers/home');
+        const redirectUrl = sessionStorage.getItem('redirect_after_login') || '/buyers/home';
+        sessionStorage.removeItem('redirect_after_login');
+        navigate(redirectUrl);
       } else {
         // Signup flow - store user data in sessionStorage for CompleteProfile page
         sessionStorage.setItem('oauth_user_id', user.id);

--- a/apps/dashboard/src/pages/auth/SignIn.tsx
+++ b/apps/dashboard/src/pages/auth/SignIn.tsx
@@ -70,7 +70,9 @@ export default function SignIn() {
         variant: 'success',
       });
 
-      navigate('/buyers/home');
+      const redirectUrl = sessionStorage.getItem('redirect_after_login') || '/buyers/home';
+      sessionStorage.removeItem('redirect_after_login');
+      navigate(redirectUrl);
     } catch (error: any) {
       trackSignin('error', 'email', { error: error.message?.substring(0, 50) });
 


### PR DESCRIPTION
## Summary

- **Preserve intended URL after login redirect**: Users visiting a shared deep-link while logged out are now redirected back to that URL after signing in, instead of always landing on the homepage. Applies to both email and OAuth login in dashboard and creator apps. Includes cleanup on all error paths to prevent stale redirects.
- **Remove bundle discount and yearly pricing from creator Plan page**: Simplified pricing display to monthly-only plans with launch promo pricing.
- **Fix TitleDetail crash and apply homepage design rollout**: Resolved a crash on the creator TitleDetail page and rolled out design improvements across multiple creator pages (Home, Profile, Titles, Billing, etc.).
- **Streamline CLAUDE.md documentation**: Simplified creator CLAUDE.md for better Claude Code productivity.

## Test plan

- [ ] Visit `dashboard.kstorybridge.com/buyers/titles/some-id` while logged out, sign in, verify redirect to `/buyers/titles/some-id`
- [ ] Same test with Google OAuth sign-in on dashboard
- [ ] Visit `creator.kstorybridge.com/titles/some-id` while logged out, sign in, verify redirect to `/titles/some-id`
- [ ] Same test with Google OAuth sign-in on creator
- [ ] Visit `/signin` directly, sign in, verify redirect to homepage (no stored redirect)
- [ ] New user signup flow still redirects to profile completion
- [ ] Creator Plan page shows monthly-only pricing without yearly/bundle options
- [ ] Creator TitleDetail page loads without crashing
- [ ] Creator homepage design renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)