### PR TITLE
feat: Format Spotlight & recent improvements

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -38,6 +38,7 @@ import Checkout from '@/pages/buyers/Checkout';
 import CheckoutSuccess from '@/pages/buyers/CheckoutSuccess';
 import CheckoutCancel from '@/pages/buyers/CheckoutCancel';
 import Featured from '@/pages/buyers/Featured';
+import FormatSpotlight from '@/pages/buyers/FormatSpotlight';
 
 // Admin pages
 import AdminTitles from '@/pages/admin/AdminTitles';
@@ -186,6 +187,16 @@ function App() {
               <TierProvider>
                 <ProtectedRoute>
                   <Featured />
+                </ProtectedRoute>
+              </TierProvider>
+            }
+          />
+          <Route
+            path="/buyers/format-spotlight/:formatType"
+            element={
+              <TierProvider>
+                <ProtectedRoute>
+                  <FormatSpotlight />
                 </ProtectedRoute>
               </TierProvider>
             }

--- a/apps/dashboard/src/components/format-spotlight/FormatInsightsTab.tsx
+++ b/apps/dashboard/src/components/format-spotlight/FormatInsightsTab.tsx
@@ -1,0 +1,120 @@
+import type { FormatAnalysis, FormatType, MicrodramaSpecificInsights } from '@/services/formatFitService';
+import { FORMAT_DISPLAY_NAMES } from '@/services/formatFitService';
+import { Icon } from '@iconify/react';
+
+interface FormatInsightsTabProps {
+  analysis: FormatAnalysis;
+  formatType: FormatType;
+}
+
+function MicrodramaInsights({ insights }: { insights: MicrodramaSpecificInsights }) {
+  return (
+    <div className="space-y-3">
+      {/* Gauges row */}
+      <div className="grid grid-cols-3 gap-3">
+        <GaugeItem label="Cliffhanger" value={insights.cliffhanger_potential} />
+        <GaugeItem label="Episode Fit" value={insights.episode_structure_fit} />
+        <GaugeItem label="Vertical" value={insights.vertical_filming_compatibility} />
+      </div>
+
+      {/* Tropes */}
+      {insights.trope_alignment && insights.trope_alignment.length > 0 && (
+        <div>
+          <p className="text-xs text-gray-500 mb-1.5">Trope Alignment</p>
+          <div className="flex flex-wrap gap-1.5">
+            {insights.trope_alignment.map((trope, i) => (
+              <span
+                key={i}
+                className="px-2 py-0.5 text-xs bg-purple-50 text-purple-700 rounded-md border border-purple-200"
+              >
+                {trope}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Platforms */}
+      {insights.target_platform_fit && insights.target_platform_fit.length > 0 && (
+        <div>
+          <p className="text-xs text-gray-500 mb-1.5">Target Platforms</p>
+          <div className="flex flex-wrap gap-1.5">
+            {insights.target_platform_fit.map((platform, i) => (
+              <span
+                key={i}
+                className="px-2 py-0.5 text-xs bg-blue-50 text-blue-700 rounded-md border border-blue-200"
+              >
+                {platform}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GaugeItem({ label, value }: { label: string; value: number }) {
+  const percentage = Math.min(100, Math.max(0, value));
+  const barColor =
+    percentage >= 80 ? 'bg-green-500' : percentage >= 60 ? 'bg-blue-500' : 'bg-gray-400';
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-xs text-gray-600">{label}</span>
+        <span className="text-xs font-medium text-gray-900">{value}</span>
+      </div>
+      <div className="w-full h-1.5 bg-gray-100 rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full ${barColor}`}
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function FormatInsightsTab({ analysis, formatType }: FormatInsightsTabProps) {
+  const formatName = FORMAT_DISPLAY_NAMES[formatType] || formatType;
+
+  // Microdrama with format_specific data
+  if (formatType === 'microdrama' && analysis.format_specific) {
+    return (
+      <div className="space-y-3">
+        <p className="text-xs font-semibold text-gray-500">
+          {formatName} Insights
+        </p>
+        <MicrodramaInsights insights={analysis.format_specific} />
+      </div>
+    );
+  }
+
+  // Fallback: recommendations list
+  if (analysis.recommendations && analysis.recommendations.length > 0) {
+    return (
+      <div className="space-y-2">
+        <p className="text-xs font-semibold text-gray-500">
+          {formatName} Recommendations
+        </p>
+        <ul className="space-y-1.5">
+          {analysis.recommendations.map((rec, i) => (
+            <li key={i} className="flex items-start gap-2 text-sm text-gray-700">
+              <Icon
+                icon="solar:lightbulb-bold-duotone"
+                className="h-4 w-4 text-blue-500 mt-0.5 shrink-0"
+              />
+              <span>{rec}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+
+  return (
+    <p className="text-sm text-gray-400">
+      No format-specific insights available for {formatName}.
+    </p>
+  );
+}

--- a/apps/dashboard/src/components/format-spotlight/FormatSpotlightCard.tsx
+++ b/apps/dashboard/src/components/format-spotlight/FormatSpotlightCard.tsx
@@ -1,0 +1,241 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Icon } from '@iconify/react';
+import RadarChart from './RadarChart';
+import FormatInsightsTab from './FormatInsightsTab';
+import type { FormatAnalysis, FormatType } from '@/services/formatFitService';
+import { getFitLevel, getFitLevelLabel } from '@/services/formatFitService';
+
+interface TitleData {
+  title_id: string;
+  title_name_en: string | null;
+  title_name_kr: string | null;
+  title_image: string | null;
+  genre: string[] | null;
+  content_format: string | null;
+  tone: string | null;
+  story_author: string | null;
+  art_author: string | null;
+  rating: number | null;
+  views: number | null;
+}
+
+interface FormatSpotlightCardProps {
+  title: TitleData;
+  analysis: FormatAnalysis;
+  formatType: FormatType;
+  rank?: number;
+  onCardClick?: (titleId: string) => void;
+}
+
+type TabType = 'strengths' | 'challenges' | 'insights';
+
+function formatViews(views: number): string {
+  if (views >= 1_000_000) return `${(views / 1_000_000).toFixed(1)}M`;
+  if (views >= 1_000) return `${(views / 1_000).toFixed(0)}K`;
+  return views.toString();
+}
+
+export default function FormatSpotlightCard({
+  title,
+  analysis,
+  formatType,
+  rank,
+  onCardClick,
+}: FormatSpotlightCardProps) {
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState<TabType>('strengths');
+
+  const score = analysis.overall_score;
+  const fitLevel = getFitLevel(score);
+  const fitLevelLabel = getFitLevelLabel(score);
+  const radarColor =
+    fitLevel === 'excellent'
+      ? '#22c55e'
+      : fitLevel === 'good'
+        ? '#3b82f6'
+        : '#9ca3af';
+
+  const handleClick = () => {
+    if (onCardClick) {
+      onCardClick(title.title_id);
+    } else {
+      navigate(`/buyers/titles/${title.title_id}`);
+    }
+  };
+
+  const tabs: { key: TabType; label: string }[] = [
+    { key: 'strengths', label: 'Strengths' },
+    { key: 'challenges', label: 'Challenges' },
+    { key: 'insights', label: 'Format Insights' },
+  ];
+
+  return (
+    <div className={`bg-transparent border border-gray-300 shadow-none rounded-2xl overflow-hidden hover:border-gray-400 transition-colors ${
+      fitLevel === 'excellent'
+        ? 'border-t-[3px] border-t-green-500'
+        : fitLevel === 'good'
+          ? 'border-t-[3px] border-t-blue-500'
+          : 'border-t-[3px] border-t-gray-400'
+    }`}>
+      {/* Top Section */}
+      <div
+        className="p-4 sm:p-5 cursor-pointer hover:bg-gray-50/50 transition-colors"
+        onClick={handleClick}
+      >
+        <div className="flex flex-col sm:flex-row gap-4">
+          {/* Image */}
+          <div className="w-full sm:w-36 md:w-44 shrink-0">
+            <div className="relative aspect-[3/4] w-full rounded-xl overflow-hidden bg-gray-100">
+              {title.title_image ? (
+                <img
+                  src={title.title_image}
+                  alt={title.title_name_en || 'Title'}
+                  className="w-full h-full object-cover"
+                />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center">
+                  <Icon icon="solar:book-bold-duotone" className="h-12 w-12 text-gray-300" />
+                </div>
+              )}
+              {rank && (
+                <div className="absolute top-2 left-2 w-8 h-8 rounded-full bg-black ring-2 ring-white/50 text-white text-sm font-bold flex items-center justify-center">
+                  {rank}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Metadata */}
+          <div className="flex-1 min-w-0">
+            <h3 className="text-lg font-bold text-black truncate">
+              {title.title_name_en || title.title_name_kr || 'Untitled'}
+            </h3>
+            {title.title_name_kr && title.title_name_en && (
+              <p className="text-sm text-gray-500 truncate">{title.title_name_kr}</p>
+            )}
+
+            {/* Genre badges */}
+            <div className="flex flex-wrap gap-1.5 mt-2">
+              {title.genre?.slice(0, 3).map((g, i) => (
+                <span
+                  key={i}
+                  className="bg-gradient-to-r from-cyan-100 to-cyan-50 text-cyan-800 px-2 py-0.5 rounded-md text-xs font-medium border border-cyan-200"
+                >
+                  {g}
+                </span>
+              ))}
+              {title.content_format && (
+                <span className="bg-gradient-to-r from-purple-100 to-purple-50 text-purple-800 px-2 py-0.5 rounded-md text-xs font-medium border border-purple-200">
+                  {title.content_format}
+                </span>
+              )}
+              {title.tone && (
+                <span className="bg-gradient-to-r from-blue-100 to-blue-50 text-blue-800 px-2 py-0.5 rounded-md text-xs font-medium border border-blue-200">
+                  {title.tone}
+                </span>
+              )}
+            </div>
+
+            {/* Authors & stats */}
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-2 text-xs text-gray-500">
+              {title.story_author && (
+                <span>Story: {title.story_author}</span>
+              )}
+              {title.art_author && (
+                <span>Art: {title.art_author}</span>
+              )}
+              {title.rating != null && title.rating > 0 && (
+                <span className="flex items-center gap-0.5">
+                  <Icon icon="solar:star-bold" className="h-3.5 w-3.5 text-amber-400" />
+                  {title.rating.toFixed(1)}
+                </span>
+              )}
+              {title.views != null && title.views > 0 && (
+                <span>{formatViews(title.views)} views</span>
+              )}
+            </div>
+
+            {/* Summary */}
+            {analysis.summary && (
+              <p className="mt-2 text-sm text-gray-600 line-clamp-2 border-l-2 border-gray-200 pl-3">{analysis.summary}</p>
+            )}
+          </div>
+
+          {/* Radar Chart */}
+          <div className="shrink-0 flex items-center justify-center sm:justify-end">
+            <RadarChart
+              dimensions={analysis.dimensions.map((d) => ({
+                dimension: d.dimension,
+                score: d.score,
+                reason: d.reason,
+              }))}
+              size={200}
+              color={radarColor}
+              showLabels
+              centerLabel={String(score)}
+              centerSublabel={fitLevelLabel}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom Section - Tabs */}
+      <div className="border-t border-gray-200">
+        {/* Tab headers */}
+        <div className="flex gap-1 px-2 pt-2">
+          {tabs.map((tab) => (
+            <button
+              key={tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              className={`flex-1 py-3 text-xs font-medium transition-colors rounded-lg ${
+                activeTab === tab.key
+                  ? 'text-black bg-gray-100'
+                  : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Tab content */}
+        <div className="p-4 min-h-[120px]">
+          {activeTab === 'strengths' && (
+            <ul className="space-y-1.5">
+              {analysis.strengths.length > 0 ? (
+                analysis.strengths.map((s, i) => (
+                  <li key={i} className="flex items-start gap-2 text-sm text-gray-700">
+                    <Icon icon="solar:check-circle-bold" className="h-4 w-4 text-green-500 mt-0.5 shrink-0" />
+                    <span>{s}</span>
+                  </li>
+                ))
+              ) : (
+                <p className="text-sm text-gray-400">No strengths data available.</p>
+              )}
+            </ul>
+          )}
+
+          {activeTab === 'challenges' && (
+            <ul className="space-y-1.5">
+              {analysis.challenges.length > 0 ? (
+                analysis.challenges.map((c, i) => (
+                  <li key={i} className="flex items-start gap-2 text-sm text-gray-700">
+                    <Icon icon="solar:danger-triangle-bold" className="h-4 w-4 text-orange-500 mt-0.5 shrink-0" />
+                    <span>{c}</span>
+                  </li>
+                ))
+              ) : (
+                <p className="text-sm text-gray-400">No challenges data available.</p>
+              )}
+            </ul>
+          )}
+
+          {activeTab === 'insights' && (
+            <FormatInsightsTab analysis={analysis} formatType={formatType} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/format-spotlight/RadarChart.tsx
+++ b/apps/dashboard/src/components/format-spotlight/RadarChart.tsx
@@ -1,0 +1,212 @@
+import { useState } from 'react';
+
+interface DimensionInput {
+  dimension: string;
+  score: number;
+  reason?: string;
+}
+
+interface RadarChartProps {
+  dimensions: DimensionInput[];
+  size?: number;
+  color?: string;
+  showLabels?: boolean;
+  centerLabel?: string;
+  centerSublabel?: string;
+}
+
+const DIMENSION_ABBREVS: Record<string, string> = {
+  narrative_structure: 'Narr',
+  character_suitability: 'Char',
+  visual_requirements: 'Vis',
+  pacing_fit: 'Pace',
+  production_feasibility: 'Prod',
+  audience_alignment: 'Aud',
+  genre_fit: 'Genre',
+};
+
+const DIMENSION_FULL_NAMES: Record<string, string> = {
+  narrative_structure: 'Narrative Structure',
+  character_suitability: 'Character Suitability',
+  visual_requirements: 'Visual Requirements',
+  pacing_fit: 'Pacing Fit',
+  production_feasibility: 'Production Feasibility',
+  audience_alignment: 'Audience Alignment',
+  genre_fit: 'Genre Fit',
+};
+
+function polarToCartesian(cx: number, cy: number, r: number, angleRad: number) {
+  return {
+    x: cx + r * Math.cos(angleRad),
+    y: cy + r * Math.sin(angleRad),
+  };
+}
+
+function getPolygonPoints(cx: number, cy: number, r: number, n: number): string {
+  const points: string[] = [];
+  for (let i = 0; i < n; i++) {
+    const angle = (Math.PI * 2 * i) / n - Math.PI / 2;
+    const { x, y } = polarToCartesian(cx, cy, r, angle);
+    points.push(`${x},${y}`);
+  }
+  return points.join(' ');
+}
+
+export default function RadarChart({
+  dimensions,
+  size = 180,
+  color,
+  showLabels = true,
+  centerLabel,
+  centerSublabel,
+}: RadarChartProps) {
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+
+  const n = dimensions.length;
+  if (n === 0) return null;
+
+  const cx = size / 2;
+  const cy = size / 2;
+  const maxR = size * 0.35;
+  const labelR = size * 0.46;
+
+  // Grid levels at 25, 50, 75, 100
+  const gridLevels = [25, 50, 75, 100];
+
+  // Data polygon points
+  const dataPoints = dimensions.map((d, i) => {
+    const angle = (Math.PI * 2 * i) / n - Math.PI / 2;
+    const r = (d.score / 100) * maxR;
+    return polarToCartesian(cx, cy, r, angle);
+  });
+  const dataPolygon = dataPoints.map((p) => `${p.x},${p.y}`).join(' ');
+
+  // Fill color
+  const fillColor = color || '#4C9C9B';
+
+  return (
+    <div className="relative" style={{ width: size, height: size }}>
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+        {/* Grid polygons */}
+        {gridLevels.map((level) => (
+          <polygon
+            key={level}
+            points={getPolygonPoints(cx, cy, (level / 100) * maxR, n)}
+            fill="none"
+            stroke="#e5e7eb"
+            strokeWidth={level === 100 ? 1.5 : 0.75}
+          />
+        ))}
+
+        {/* Axis lines */}
+        {dimensions.map((_, i) => {
+          const angle = (Math.PI * 2 * i) / n - Math.PI / 2;
+          const end = polarToCartesian(cx, cy, maxR, angle);
+          return (
+            <line
+              key={i}
+              x1={cx}
+              y1={cy}
+              x2={end.x}
+              y2={end.y}
+              stroke="#d1d5db"
+              strokeWidth={0.75}
+            />
+          );
+        })}
+
+        {/* Data polygon */}
+        <polygon
+          points={dataPolygon}
+          fill={fillColor}
+          fillOpacity={0.2}
+          stroke={fillColor}
+          strokeWidth={2}
+        />
+
+        {/* Data points */}
+        {dataPoints.map((p, i) => (
+          <circle
+            key={i}
+            cx={p.x}
+            cy={p.y}
+            r={3}
+            fill={fillColor}
+            stroke="white"
+            strokeWidth={1.5}
+            className="cursor-pointer"
+            onMouseEnter={() => setHoveredIndex(i)}
+            onMouseLeave={() => setHoveredIndex(null)}
+          />
+        ))}
+
+        {/* Axis labels */}
+        {showLabels &&
+          dimensions.map((d, i) => {
+            const angle = (Math.PI * 2 * i) / n - Math.PI / 2;
+            const pos = polarToCartesian(cx, cy, labelR, angle);
+            const abbrev = DIMENSION_ABBREVS[d.dimension] || d.dimension.slice(0, 4);
+            return (
+              <text
+                key={i}
+                x={pos.x}
+                y={pos.y}
+                textAnchor="middle"
+                dominantBaseline="central"
+                className="fill-gray-500 select-none pointer-events-none"
+                fontSize={10}
+                fontWeight={500}
+              >
+                {abbrev}
+              </text>
+            );
+          })}
+
+        {/* Center label */}
+        {centerLabel && (
+          <>
+            <text
+              x={cx}
+              y={centerSublabel ? cy - 6 : cy}
+              textAnchor="middle"
+              dominantBaseline="central"
+              className="fill-gray-900 font-bold"
+              fontSize={18}
+            >
+              {centerLabel}
+            </text>
+            {centerSublabel && (
+              <text
+                x={cx}
+                y={cy + 12}
+                textAnchor="middle"
+                dominantBaseline="central"
+                className="fill-gray-500"
+                fontSize={9}
+                fontWeight={500}
+              >
+                {centerSublabel}
+              </text>
+            )}
+          </>
+        )}
+      </svg>
+
+      {/* Tooltip */}
+      {hoveredIndex !== null && (
+        <div
+          className="absolute z-10 px-2.5 py-1.5 bg-gray-900 text-white text-xs rounded-lg shadow-lg pointer-events-none whitespace-nowrap"
+          style={{
+            left: dataPoints[hoveredIndex].x,
+            top: Math.max(4, dataPoints[hoveredIndex].y - 32),
+            transform: 'translateX(-50%)',
+          }}
+        >
+          {DIMENSION_FULL_NAMES[dimensions[hoveredIndex].dimension] ||
+            dimensions[hoveredIndex].dimension}
+          : {dimensions[hoveredIndex].score}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/format-spotlight/index.ts
+++ b/apps/dashboard/src/components/format-spotlight/index.ts
@@ -1,0 +1,3 @@
+export { default as FormatSpotlightCard } from './FormatSpotlightCard';
+export { default as RadarChart } from './RadarChart';
+export { default as FormatInsightsTab } from './FormatInsightsTab';

--- a/apps/dashboard/src/components/layout/BuyerSidebar.tsx
+++ b/apps/dashboard/src/components/layout/BuyerSidebar.tsx
@@ -20,6 +20,7 @@ const getDiscoverItems = (): MenuItem[] => {
     { title: 'Comps Navigator', href: '/buyers/comps-navigator', icon: 'solar:compass-bold-duotone' },
     { title: 'Mandate Matcher', href: '/buyers/mandates', icon: 'solar:stars-bold-duotone' },
     { title: 'Trending', href: '/buyers/trending', icon: 'solar:graph-up-bold-duotone' },
+    { title: 'Microdrama Spotlight', href: '/buyers/format-spotlight/microdrama', icon: 'solar:smartphone-bold-duotone' },
     { title: 'Titles', href: '/buyers/titles', icon: 'solar:book-bold-duotone' },
     { title: 'Saved', href: '/buyers/saved', icon: 'solar:heart-bold-duotone' },
     { title: 'Plan', href: '/buyers/plan', icon: 'solar:card-bold-duotone' },
@@ -104,12 +105,12 @@ export function BuyerSidebar() {
                       onClick={handleLinkClick}
                       className={cn(
                         'flex items-center gap-3 px-4 py-3 rounded-xl font-medium transition-all duration-200',
-                        location.pathname === item.href
+                        location.pathname === item.href || location.pathname.startsWith(item.href + '/')
                           ? 'bg-hanok-teal/10 text-hanok-teal shadow-sm border border-hanok-teal/20'
                           : 'text-gray-700 hover:bg-hanok-teal/5'
                       )}
                     >
-                      <Icon icon={item.icon} className={cn("h-5 w-5", location.pathname === item.href ? "" : "text-gray-400")} />
+                      <Icon icon={item.icon} className={cn("h-5 w-5", location.pathname === item.href || location.pathname.startsWith(item.href + '/') ? "" : "text-gray-400")} />
                       <span>{item.title}</span>
                       {item.badge && (
                         <span className="ml-auto px-2 py-0.5 text-xs font-semibold rounded-full bg-red-500 text-white">

--- a/apps/dashboard/src/pages/buyers/FormatSpotlight.tsx
+++ b/apps/dashboard/src/pages/buyers/FormatSpotlight.tsx
@@ -1,0 +1,133 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { BuyerLayout } from '@/components/layout/BuyerLayout';
+import { Icon } from '@iconify/react';
+import { FormatSpotlightCard } from '@/components/format-spotlight';
+import {
+  FORMAT_DISPLAY_NAMES,
+  FORMAT_ICONS,
+  FORMAT_DESCRIPTIONS,
+  type FormatType,
+} from '@/services/formatFitService';
+import { getFormatSpotlightData } from '@/services/formatFitService';
+import { trackFormatSpotlightView, trackFormatSpotlightCardClick } from '@/utils/analytics';
+import { useEffect } from 'react';
+
+const VALID_FORMATS: FormatType[] = ['film', 'tv_series', 'animation', 'microdrama', 'audio_drama'];
+
+export default function FormatSpotlight() {
+  const { formatType } = useParams<{ formatType: string }>();
+  const navigate = useNavigate();
+
+  const validFormat = VALID_FORMATS.includes(formatType as FormatType)
+    ? (formatType as FormatType)
+    : null;
+
+  useEffect(() => {
+    if (validFormat) {
+      trackFormatSpotlightView(validFormat);
+    }
+  }, [validFormat]);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['format-spotlight', validFormat],
+    queryFn: () => getFormatSpotlightData(validFormat!),
+    enabled: !!validFormat,
+  });
+
+  if (!validFormat) {
+    return (
+      <BuyerLayout>
+        <div className="w-full max-w-6xl mx-auto px-4 sm:px-6 py-4 sm:py-6">
+          <div className="flex flex-col items-center justify-center py-20">
+            <div className="w-16 h-16 rounded-full bg-gray-100 flex items-center justify-center mb-4">
+              <Icon icon="solar:danger-triangle-bold-duotone" className="h-8 w-8 text-gray-400" />
+            </div>
+            <h3 className="text-lg font-semibold text-gray-900 mb-2">Invalid Format</h3>
+            <p className="text-gray-600 text-sm text-center max-w-md">
+              The format type "{formatType}" is not recognized.
+            </p>
+          </div>
+        </div>
+      </BuyerLayout>
+    );
+  }
+
+  const icon = FORMAT_ICONS[validFormat];
+  const displayName = FORMAT_DISPLAY_NAMES[validFormat];
+  const description = FORMAT_DESCRIPTIONS[validFormat];
+
+  const handleCardClick = (titleId: string, rank: number) => {
+    trackFormatSpotlightCardClick(titleId, validFormat, rank);
+    navigate(`/buyers/titles/${titleId}`);
+  };
+
+  return (
+    <BuyerLayout>
+      <div className="w-full max-w-6xl mx-auto px-4 sm:px-6 py-4 sm:py-6 space-y-6">
+        {/* Header */}
+        <div className="space-y-3">
+          <div className="flex items-center gap-3">
+            <div className="bg-gradient-to-br from-hanok-teal to-hanok-teal/80 p-3 rounded-2xl shadow-lg">
+              <span className="text-2xl">{icon}</span>
+            </div>
+            <div>
+              <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-hanok-teal">
+                {displayName} Spotlight
+              </h1>
+              <p className="text-base sm:text-lg text-gray-600 mt-1">{description}</p>
+            </div>
+          </div>
+          <p className="text-sm sm:text-base text-gray-600">
+            Top Korean titles ranked by AI-analyzed {displayName.toLowerCase()} adaptation potential.
+          </p>
+        </div>
+
+        {/* Loading State */}
+        {isLoading && (
+          <div className="flex flex-col items-center justify-center py-20">
+            <Icon icon="solar:refresh-circle-bold-duotone" className="h-12 w-12 text-hanok-teal animate-spin mb-4" />
+            <p className="text-gray-600 text-sm">Analyzing {displayName.toLowerCase()} potential...</p>
+          </div>
+        )}
+
+        {/* Error State */}
+        {error && (
+          <div className="p-6 bg-red-50 border border-red-200 rounded-2xl">
+            <p className="text-red-800 font-semibold mb-2">Failed to load spotlight data</p>
+            <p className="text-red-600 text-sm">Please try again later or contact support if the problem persists.</p>
+          </div>
+        )}
+
+        {/* Empty State */}
+        {!isLoading && !error && data && data.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-20">
+            <div className="w-16 h-16 rounded-full bg-gray-100 flex items-center justify-center mb-4">
+              <span className="text-2xl">{icon}</span>
+            </div>
+            <h3 className="text-lg font-semibold text-gray-900 mb-2">No Titles Found</h3>
+            <p className="text-gray-600 text-sm text-center max-w-md">
+              No titles currently meet the threshold for {displayName.toLowerCase()} adaptation. Check back as more titles are analyzed.
+            </p>
+          </div>
+        )}
+
+        {/* Cards */}
+        {!isLoading && !error && data && data.length > 0 && (
+          <div className="space-y-4">
+            {data.map((item, index) => (
+              <FormatSpotlightCard
+                key={item.title.title_id}
+                title={item.title}
+                analysis={item.analysis}
+                formatType={validFormat}
+                rank={index + 1}
+                onCardClick={(titleId) => handleCardClick(titleId, index + 1)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </BuyerLayout>
+  );
+}

--- a/apps/dashboard/src/services/formatFitService.ts
+++ b/apps/dashboard/src/services/formatFitService.ts
@@ -130,6 +130,92 @@ export async function deleteFormatFit(titleId: string) {
 }
 
 // =====================================================================
+// FORMAT SPOTLIGHT DATA
+// =====================================================================
+
+interface SpotlightTitleData {
+  title_id: string;
+  title_name_en: string | null;
+  title_name_kr: string | null;
+  title_image: string | null;
+  genre: string[] | null;
+  content_format: string | null;
+  tone: string | null;
+  story_author: string | null;
+  art_author: string | null;
+  rating: number | null;
+  views: number | null;
+}
+
+interface SpotlightItem {
+  title: SpotlightTitleData;
+  analysis: import('@kstorybridge/tools').FormatAnalysis;
+}
+
+/**
+ * Get format spotlight data: titles joined with format fit analysis,
+ * filtered by minimum score and sorted descending.
+ */
+export async function getFormatSpotlightData(
+  formatType: import('@kstorybridge/tools').FormatType,
+  minScore: number = 50
+): Promise<SpotlightItem[]> {
+  const scoreKey = `${formatType}_score`;
+  const analysisKey = `${formatType}_analysis`;
+
+  // Fetch all format fit records with scores and analyses
+  const { data: fitData, error: fitError } = await supabase
+    .from('title_format_fit')
+    .select('title_id, film_score, tv_series_score, animation_score, microdrama_score, audio_drama_score, film_analysis, tv_series_analysis, animation_analysis, microdrama_analysis, audio_drama_analysis');
+
+  if (fitError) {
+    console.error('[FormatSpotlight] Fetch error:', fitError);
+    throw new Error('Failed to fetch format spotlight data');
+  }
+
+  // Filter and sort by the target format score
+  const filtered = (fitData || [])
+    .filter((row) => {
+      const score = (row as Record<string, unknown>)[scoreKey] as number | null;
+      return score !== null && score >= minScore;
+    })
+    .sort((a, b) => {
+      const scoreA = ((a as Record<string, unknown>)[scoreKey] as number) || 0;
+      const scoreB = ((b as Record<string, unknown>)[scoreKey] as number) || 0;
+      return scoreB - scoreA;
+    });
+
+  if (filtered.length === 0) return [];
+
+  // Fetch title details for matching titles
+  const titleIds = filtered.map((r) => r.title_id);
+  const { data: titles, error: titlesError } = await supabase
+    .from('titles')
+    .select('title_id, title_name_en, title_name_kr, title_image, genre, content_format, tone, story_author, art_author, rating, views')
+    .in('title_id', titleIds);
+
+  if (titlesError) {
+    console.error('[FormatSpotlight] Titles fetch error:', titlesError);
+    throw new Error('Failed to fetch title details');
+  }
+
+  const titlesMap = new Map((titles || []).map((t) => [t.title_id, t]));
+
+  return filtered
+    .map((row) => {
+      const titleData = titlesMap.get(row.title_id);
+      if (!titleData) return null;
+      const analysis = (row as Record<string, unknown>)[analysisKey] as import('@kstorybridge/tools').FormatAnalysis;
+      if (!analysis) return null;
+      return {
+        title: titleData as SpotlightTitleData,
+        analysis,
+      };
+    })
+    .filter((item): item is SpotlightItem => item !== null);
+}
+
+// =====================================================================
 // EXPORT SERVICE OBJECT (for backward compatibility)
 // =====================================================================
 

--- a/apps/dashboard/src/utils/analytics.ts
+++ b/apps/dashboard/src/utils/analytics.ts
@@ -1796,6 +1796,40 @@ export const trackTrialSignupCtaClicked = (
   });
 };
 
+// --- FORMAT SPOTLIGHT ---
+
+/**
+ * Track format spotlight page view
+ * @param formatType - The format type being viewed
+ */
+export const trackFormatSpotlightView = (
+  formatType: string
+): void => {
+  trackEvent('format_spotlight_view', {
+    format_type: formatType,
+    timestamp: new Date().toISOString(),
+  });
+};
+
+/**
+ * Track format spotlight card click
+ * @param titleId - UUID of the title
+ * @param formatType - The format type
+ * @param rank - Position in the list (1-indexed)
+ */
+export const trackFormatSpotlightCardClick = (
+  titleId: string,
+  formatType: string,
+  rank: number
+): void => {
+  trackEvent('format_spotlight_card_click', {
+    title_id: titleId,
+    format_type: formatType,
+    rank,
+    timestamp: new Date().toISOString(),
+  });
+};
+
 // Extend Window interface for TypeScript
 declare global {
   interface Window {

--- a/apps/website/src/App.tsx
+++ b/apps/website/src/App.tsx
@@ -1,10 +1,13 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Toaster, TooltipProvider } from "@kstorybridge/ui";
 import { lazy, Suspense } from "react";
 
 import AnalyticsProvider from "./components/AnalyticsProvider";
 import SessionTracker from "./components/SessionTracker";
 import CookieBanner from "./components/CookieBanner";
+
+const queryClient = new QueryClient();
 
 // Lazy load page components for code splitting
 const HomePage = lazy(() => import("./pages/HomePage"));
@@ -35,6 +38,7 @@ const MandateMatcherFeaturePage = lazy(() => import("./pages/features/MandateMat
 const HowToProducersPage = lazy(() => import("./pages/HowToProducersPage"));
 const DiaryPage = lazy(() => import("./pages/DiaryPage"));
 const DiaryEntryPage = lazy(() => import("./pages/DiaryEntryPage"));
+const FormatSpotlightPage = lazy(() => import("./pages/FormatSpotlightPage"));
 
 // Loading fallback component
 const PageLoader = () => (
@@ -44,9 +48,10 @@ const PageLoader = () => (
 );
 
 const App = () => (
-  <TooltipProvider>
-    <Toaster />
-    <BrowserRouter>
+  <QueryClientProvider client={queryClient}>
+    <TooltipProvider>
+      <Toaster />
+      <BrowserRouter>
         <AnalyticsProvider />
         <SessionTracker />
         <CookieBanner />
@@ -65,6 +70,7 @@ const App = () => (
           <Route path="/how-to/producers" element={<HowToProducersPage />} />
           <Route path="/diary" element={<DiaryPage />} />
           <Route path="/diary/:date" element={<DiaryEntryPage />} />
+          <Route path="/format-spotlight/:formatType" element={<FormatSpotlightPage />} />
 
           {/* PREVIEW ROUTES - Only available in development */}
           {import.meta.env.DEV && <Route path="/producers-preview" element={<ProducersPagePreview />} />}
@@ -88,8 +94,9 @@ const App = () => (
           <Route path="*" element={<NotFound />} />
           </Routes>
         </Suspense>
-      </BrowserRouter>
-    </TooltipProvider>
+        </BrowserRouter>
+      </TooltipProvider>
+  </QueryClientProvider>
 );
 
 export default App;


### PR DESCRIPTION
## Summary

- **Format Spotlight page** for dashboard and website apps — displays titles ranked by format fit score (e.g., Microdrama Spotlight)
- **QueryClientProvider** added to website app to support TanStack Query usage
- **Sidebar improvements** — Microdrama Spotlight link, better nested route active states
- **Analytics tracking** for spotlight views and card clicks
- Various other improvements since last production deploy (How To Producers page, demo accounts, login redirect fixes, etc.)

## Affected Apps
- `apps/dashboard` — new Format Spotlight page, sidebar, analytics, service
- `apps/website` — QueryClientProvider fix, Format Spotlight promo page

## Test plan
- [ ] Visit `localhost:5173/format-spotlight/microdrama` — page loads with cards
- [ ] Visit `localhost:8081/buyers/format-spotlight/microdrama` — page loads in dashboard
- [ ] Click a title card — navigates to title detail page
- [ ] Sidebar highlights Microdrama Spotlight when on format-spotlight routes
- [ ] `npm run build` passes for both apps
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)