### PR TITLE
fix: Update public title page CTA copy

### DIFF
--- a/apps/website/src/pages/PublicTitlePage.tsx
+++ b/apps/website/src/pages/PublicTitlePage.tsx
@@ -227,7 +227,7 @@ export default function PublicTitlePage() {
               className="w-full sm:w-auto bg-black hover:bg-gray-800 text-white rounded-full px-8 py-3 text-base font-medium"
               onClick={() => { window.location.href = signupUrl; }}
             >
-              Express Interest &mdash; It's Free
+              Sign Up to View the Full Analysis
             </Button>
           </div>
         </div>
@@ -268,7 +268,7 @@ export default function PublicTitlePage() {
             className="bg-black hover:bg-gray-800 text-white rounded-full px-8 py-3 text-base font-medium"
             onClick={() => { window.location.href = signupUrl; }}
           >
-            Get Access &mdash; It's Free
+            Join Now! It's Free
           </Button>
         </div>
 


### PR DESCRIPTION
## Summary
- Updated hero CTA from "Express Interest — It's Free" to "Sign Up to View the Full Analysis"
- Updated gate section CTA from "Get Access — It's Free" to "Join Now! It's Free"

## Affected Apps

| App | Files Changed | Will Auto-Deploy |
|-----|---------------|------------------|
| Website | 1 file | Yes |

## Deployment Checklist

Pre-merge:
- [x] Changes tested in staging
- [x] No database migrations
- [x] No breaking API changes

Post-merge:
- [ ] Verify production URL: https://kstorybridge.com/titles/idol-house
- [ ] Check CTA text renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)