### PR TITLE
fix: Update copyright to The Story Bridge, LLC + title detail UX redesign

### DIFF
--- a/apps/creator/src/components/Footer.tsx
+++ b/apps/creator/src/components/Footer.tsx
@@ -13,7 +13,7 @@ const Footer = () => {
         <div className="flex flex-col sm:flex-row justify-between items-center space-y-4 sm:space-y-0">
           {/* Copyright */}
           <div className="text-sm text-gray-600">
-            © 2025 KStoryBridge
+            © {new Date().getFullYear()} The Story Bridge, LLC
           </div>
 
           {/* Links */}

--- a/apps/dashboard/src/pages/admin/EmailTemplates.tsx
+++ b/apps/dashboard/src/pages/admin/EmailTemplates.tsx
@@ -252,7 +252,7 @@ function getEmailFooter(): string {
         <a href="mailto:${BRAND.contact.support}" class="footer-link">Contact Support</a>
       </div>
       <p class="footer-text">${BRAND.contact.address}</p>
-      <p class="footer-text">&copy; ${BRAND.year} KStoryBridge. All rights reserved.</p>
+      <p class="footer-text">&copy; ${BRAND.year} The Story Bridge, LLC. All rights reserved.</p>
       <p class="footer-text" style="margin-top: 12px;">
         <a href="#" style="color: ${BRAND.colors.textMuted}; text-decoration: underline;">Unsubscribe</a>
         &nbsp;&bull;&nbsp;

--- a/apps/website/src/components/Footer.tsx
+++ b/apps/website/src/components/Footer.tsx
@@ -13,7 +13,7 @@ const Footer = () => {
         <div className="flex flex-col md:flex-row justify-between items-center space-y-4 md:space-y-0">
           {/* Copyright */}
           <div className="text-sm text-gray-600">
-            © 2025 KStoryBridge | <span className="korean-text">K스토리브릿지</span>
+            © {new Date().getFullYear()} The Story Bridge, LLC
           </div>
 
           {/* Links */}

--- a/apps/website/src/design-system/layouts/Footer.tsx
+++ b/apps/website/src/design-system/layouts/Footer.tsx
@@ -35,7 +35,7 @@ export const Footer: React.FC<FooterProps> = ({
               <Text color="inverse" weight="medium">KStoryBridge</Text>
             </div>
             <Text color="inverse" size="sm">
-              © {currentYear} KStoryBridge. All rights reserved.
+              © {currentYear} The Story Bridge, LLC. All rights reserved.
             </Text>
           </div>
         </Container>
@@ -242,7 +242,7 @@ export const Footer: React.FC<FooterProps> = ({
           {/* Bottom Footer */}
           <div className="flex flex-col md:flex-row items-center justify-between space-y-4 md:space-y-0 pt-8">
             <Text color="inverse" size="sm">
-              © {currentYear} KStoryBridge. All rights reserved.
+              © {currentYear} The Story Bridge, LLC. All rights reserved.
             </Text>
             
             <div className="flex items-center space-x-6">

--- a/supabase/functions/send-approval-email/index.ts
+++ b/supabase/functions/send-approval-email/index.ts
@@ -129,7 +129,7 @@ serve(async (req) => {
               </p>
               
               <div class="footer">
-                <p>© 2025 KStoryBridge. All rights reserved.</p>
+                <p>© ${new Date().getFullYear()} The Story Bridge, LLC. All rights reserved.</p>
                 <p>This is an automated message. Please do not reply to this email.</p>
               </div>
             </div>

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -360,7 +360,7 @@ function getEmailFooter(options: { loginUrl?: string; showUnsubscribe?: boolean 
       </div>
 
       <div class="footer-address">
-        © ${BRAND.year} ${BRAND.logo.text}. All rights reserved.<br>
+        © ${BRAND.year} The Story Bridge, LLC. All rights reserved.<br>
         ${BRAND.contact.address}
       </div>
 
@@ -664,7 +664,7 @@ Best regards,
 The KStoryBridge Team
 
 ---
-© ${BRAND.year} KStoryBridge. All rights reserved.
+© ${BRAND.year} The Story Bridge, LLC. All rights reserved.
 You're receiving this email because you created an account with us.
 `
 
@@ -727,7 +727,7 @@ ${ctaText && ctaUrl ? `${ctaText}: ${ctaUrl}` : ''}
 If you have any questions about these changes, contact us at ${BRAND.contact.support}
 
 ---
-© ${BRAND.year} KStoryBridge. All rights reserved.
+© ${BRAND.year} The Story Bridge, LLC. All rights reserved.
 `
 
       return { html, text }
@@ -934,7 +934,7 @@ Start exploring premium content: https://dashboard.kstorybridge.com/buyers/title
 Questions about your subscription? Contact us at ${BRAND.contact.support}
 
 ---
-© ${BRAND.year} KStoryBridge. All rights reserved.
+© ${BRAND.year} The Story Bridge, LLC. All rights reserved.
 Thank you for being a valued member of KStoryBridge.
 `
 
@@ -1004,7 +1004,7 @@ ${ctaText && ctaUrl ? `${ctaText}: ${ctaUrl}` : ''}
 If you have any questions, contact us at ${BRAND.contact.support}
 
 ---
-© ${BRAND.year} KStoryBridge. All rights reserved.
+© ${BRAND.year} The Story Bridge, LLC. All rights reserved.
 `
 
       return { html, text }


### PR DESCRIPTION
## Summary
- Updated all copyright notices from "KStoryBridge" to "The Story Bridge, LLC" (legal company name) across footers, email templates, and edge functions
- Made hardcoded 2025 copyright year dynamic with `getFullYear()`
- Title detail UX redesign with three-act layout and consistent cards
- Slug-based routing migration + unified title detail redirect
- Various bug fixes (poster images, comps teaser, sign-in redirect)

## Affected Apps
- Website (footer copyright)
- Creator (footer copyright)
- Dashboard (email templates)
- Edge Functions: send-email, send-approval-email (already deployed)

## Test plan
- [ ] Verify footer on kstorybridge.com shows "© 2026 The Story Bridge, LLC"
- [ ] Verify footer on creator-staging.kstorybridge.com shows same
- [ ] Verify email templates in dashboard admin show updated copyright
- [ ] Verify title detail pages render correctly with new layout
- [ ] Verify slug-based routing works for public title pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)