### PR TITLE
fix: buyer signup profile creation failure

### DIFF
--- a/apps/dashboard/src/lib/auth.test.ts
+++ b/apps/dashboard/src/lib/auth.test.ts
@@ -90,6 +90,7 @@ describe('Auth Service', () => {
           data: {
             account_type: 'buyer',
             full_name: testMetadata.full_name,
+            newsletter_consent: false,
           },
         },
       });
@@ -104,6 +105,8 @@ describe('Auth Service', () => {
           buyer_role: testMetadata.buyer_role,
           linkedin_url: undefined,
           tier: 'basic',
+          trial_session_id: undefined,
+          newsletter_consent: false,
         },
       });
     });
@@ -259,6 +262,8 @@ describe('Auth Service', () => {
           buyer_role: testMetadata.buyer_role,
           linkedin_url: undefined,
           tier: 'basic',
+          trial_session_id: undefined,
+          newsletter_consent: false,
         },
       });
     });
@@ -272,7 +277,7 @@ describe('Auth Service', () => {
       });
 
       expect(mockUpdateUser).toHaveBeenCalledWith({
-        data: { account_type: 'buyer' },
+        data: { account_type: 'buyer', newsletter_consent: false },
       });
     });
 

--- a/apps/dashboard/src/lib/auth.ts
+++ b/apps/dashboard/src/lib/auth.ts
@@ -26,6 +26,22 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number, operation: strin
 // Email validation removed - all email addresses allowed for buyer signups
 // (Previously blocked consumer domains like Gmail, Yahoo, etc.)
 
+// FunctionsHttpError.message is a generic "Edge Function returned a non-2xx status code".
+// The real JSON body lives on the attached Response (supabase-js v2 exposes it via .context).
+async function extractEdgeFunctionError(functionError: any): Promise<string> {
+  try {
+    const ctx = functionError?.context;
+    const res = ctx && typeof ctx.json === 'function' ? ctx : ctx?.response;
+    if (res && typeof res.json === 'function') {
+      const body = await res.clone().json();
+      if (body?.error) return body.error;
+    }
+  } catch {
+    // fall through to generic message
+  }
+  return functionError?.message || 'Unknown error';
+}
+
 /**
  * Email/Password Signup for Buyers
  * Sets account_type='buyer' during signup (not after)
@@ -88,8 +104,9 @@ export async function signUpWithEmail(
     );
 
     if (functionError) {
-      log('Profile creation error', functionError);
-      throw new Error(`Profile creation failed: ${functionError.message}`);
+      const serverError = await extractEdgeFunctionError(functionError);
+      log('Profile creation error', { functionError, serverError });
+      throw new Error(`Profile creation failed: ${serverError}`);
     }
 
     // Also check for application-level errors (supabase.functions.invoke returns
@@ -198,8 +215,9 @@ export async function completeOAuthProfile(
     );
 
     if (functionError) {
-      log('OAuth profile creation error', functionError);
-      throw new Error(`Profile creation failed: ${functionError.message}`);
+      const serverError = await extractEdgeFunctionError(functionError);
+      log('OAuth profile creation error', { functionError, serverError });
+      throw new Error(`Profile creation failed: ${serverError}`);
     }
 
     // Check for application-level errors (HTTP 400/500 returned in data, not error)


### PR DESCRIPTION
## Summary

Fixes signup error `Sign Up Failed: Profile creation failed: Edge Function returned a non-2xx status code` on `dashboard.kstorybridge.com/signup`.

**Root cause:** deployed `create-buyer-profile` edge function (v82) was stale — it required `buyer_company` and `buyer_role`, but the UI marks them optional. Users who left those fields blank got a generic `FunctionsHttpError` with no real error text.

**Fix:**
- Redeployed edge function to v83 (repo already had the relaxed validation from commit `81c22cd8`, never shipped)
- `apps/dashboard/src/lib/auth.ts`: parse `FunctionsHttpError.context` (the Response) in both `signUpWithEmail` and `completeOAuthProfile` so the toast surfaces the actual server error (e.g. `"Missing required fields: ..."`)
- `apps/dashboard/src/lib/auth.test.ts`: update stale assertions missing `newsletter_consent` / `trial_session_id` — all 27 tests pass

### Commits

- `d6c375c0` fix: surface real edge function errors in buyer signup
- `efe9bcd1` test: update auth.test.ts assertions for newsletter_consent and trial_session_id

### Affected Apps

| App | Files | Auto-Deploy |
|-----|-------|-------------|
| Dashboard | 2 | Yes |
| Creator | 0 | No |
| Website | 0 | No |

No migrations. No new edge function source (edge function already redeployed to prod).

### Verification

- Direct repro against prod (empty company/role): `400 → 200`
- `npx vitest run apps/dashboard/src/lib/auth.test.ts`: 27/27 pass
- `npx tsc --noEmit` in `apps/dashboard`: clean
- Independent code review via feature-dev:code-reviewer: no bugs

## Test plan

- [ ] Visit production `dashboard.kstorybridge.com/signup`, submit with Company/Role blank → "Check your email" toast, no error
- [ ] Submit with Company + Role filled → same success path, verify `user_buyers` row has the values
- [ ] Trigger an edge function error (e.g. DevTools network tamper) → toast shows the real server error, not the generic SDK message

## Rollback

Revert this PR + redeploy prior edge function version:
`npx supabase functions deploy create-buyer-profile --project-ref dlrnrgcoguxlkkcitlpd` from pre-fix commit

Generated with [Claude Code](https://claude.com/claude-code)