### PR TITLE
docs: add public brand guide and per-format spec sheets

### DIFF
--- a/marketing/brand/BRAND_GUIDE.md
+++ b/marketing/brand/BRAND_GUIDE.md
@@ -1,0 +1,320 @@
+# KStoryBridge Brand Guide
+
+**Last updated:** 2026-04-22
+**Audience:** internal teams, external designers, contractors, partner producers/agencies
+**Canonical code source:** [`packages/colors/colors.ts`](../../packages/colors/colors.ts)
+
+KStoryBridge is the bridge between Korean story IP (webtoons, web novels) and global buyers (studios, streamers, production companies). The brand has to feel **trustworthy enough for a studio to sign a deal through us**, and **aspirational enough for a creator to hand us their life's work**. Every asset we ship has to hold that tension.
+
+This guide is the single source for anyone making something that will carry the KStoryBridge name. For execution specs per format, see `specs/deck.md`, `specs/image.md`, `specs/video.md`, `specs/website.md`.
+
+---
+
+## 1. Brand at a glance
+
+**What we are:** a curated marketplace and deal-support layer that matches proven Korean IP with global buyers, then walks the rights through to close.
+
+**Voice in one line:** aspirational and concrete. Specific numbers. No jargon. Direct address.
+
+**Visual signature:** flat, confident, minimal. Korean cultural warmth (sand, teal) meets Hollywood energy (coral). System typography. No decoration for decoration's sake.
+
+**Hard guardrails (never break):**
+- **Never yellow.** Anywhere. Replace with `gray-500` (#6B7280) or a brand color.
+- **Cards on marketing surfaces are flat.** `bg-transparent border-gray-300 shadow-none rounded-2xl`. No shadows, no solid fills.
+- **Audience color routes the artifact.** Teal for buyers, coral for creators. Mixing confuses the reader.
+- **Container is always `max-w-7xl` (1280px) centered.** Never wider.
+- **Body copy is `text-gray-600`. Headings are `text-black`.** Not `text-gray-900`.
+
+---
+
+## 2. Color system
+
+All hex values below come from [`packages/colors/colors.ts`](../../packages/colors/colors.ts). If a doc contradicts that file, that file wins.
+
+### 2.1 Core palette
+
+| Token | Hex (DEFAULT) | Primary role |
+| --- | --- | --- |
+| `hanok-teal` | **#4C9C9B** | Buyer/producer primary. Trust, AI, technology. |
+| `sunrise-coral` | **#FF6B6B** | Creator primary. Passion, creative energy. |
+| `midnight-ink` | **#1C1C1C** | Hero headlines, deep text, high-contrast numbers. |
+| `porcelain-blue` | **#C3E3E2** | Support/legal/deal accents. Soft backgrounds. |
+| `warm-sand` | **#F5E9D7** | Korean cultural accent. Neutral warmth. |
+| `snow-white` | **#FFFFFF** | Page background, card foreground. |
+| `pro-purple` | **#AF52DE** | Dashboard Pro tier badge only. Do not use on marketing surfaces. |
+
+### 2.2 Full scale
+
+Each brand color has shades 50–900. Most surfaces only need DEFAULT + 50 (wash) + 600 (hover/press). Full scales live in the engineering design tokens doc (`/.claude/skills/kstorybridge-design/tokens.md`).
+
+### 2.3 Audience routing
+
+| Surface | Primary color | When |
+| --- | --- | --- |
+| Creator-facing (pitching to writers/studios) | `sunrise-coral` | Creator landing pages, creator onboarding, creator pitch decks, creator social |
+| Buyer-facing (pitching to producers/studios) | `hanok-teal` | Buyer landing pages, buyer product, producer decks, buyer social |
+| Dual-audience (homepage, About, company news) | Teal lead + coral accent | ~70/30 split. Coral appears on creator-focused sections only. |
+| Rights / legal / deal content | `porcelain-blue` | Regardless of audience. Signals precision. |
+| Korean cultural content | `warm-sand` | Regardless of audience. Signals heritage. |
+
+**Why this matters:** creators and buyers have opposite emotional drivers. Creators buy on inspiration; buyers buy on confidence. Splitting the primary color lets us speak to both without one sounding watered-down.
+
+### 2.4 Neutrals
+
+Use stock Tailwind gray. Do not recolor.
+
+| Class | Hex | Use |
+| --- | --- | --- |
+| `gray-50` | #F9FAFB | Lightest wash |
+| `gray-100` | #F3F4F6 | Secondary button hover |
+| `gray-200` | #E5E7EB | Subtle dividers |
+| `gray-300` | #D1D5DB | **Standard card + button border** |
+| `gray-500` | #6B7280 | **Replacement for any would-be yellow** |
+| `gray-600` | #4B5563 | **Body text color** |
+| `gray-700` | #374151 | Stronger body text |
+
+### 2.5 Status colors (product only, not marketing)
+
+`red-*` for error, `green-*` for success, `blue-*` for info. Tailwind defaults. Do not appear on marketing surfaces except in error states.
+
+---
+
+## 3. Typography
+
+### 3.1 Font stack
+
+```
+-apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text",
+"Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif
+```
+
+**No webfont loaded.** SF Pro on Apple, Segoe UI on Windows, Roboto on Android. Intentional: we want speed, familiarity, and zero licensing friction for contractors.
+
+For printed assets or sealed PDFs (decks exported for partners), embed **Inter** as the SF Pro substitute. Never use serif, display, or handwritten fonts — off-brand.
+
+### 3.2 Scale
+
+| Role | Size (px) | Weight | Color |
+| --- | --- | --- | --- |
+| Deck hero | 60–72 | Bold | `midnight-ink` |
+| Landing hero | 30 / 36 / 48 (responsive) | Bold | `midnight-ink` or `black` |
+| Section head | 24 / 30 | Bold | `black` |
+| Subsection | 20 | Semibold | `black` |
+| Card title | 18 | Semibold | `black` |
+| Body | 16 | Regular | `gray-600` |
+| Body small | 14 | Regular | `gray-600` |
+| Caption / meta | 12 | Semibold | varies |
+| BAN (big-ass number) | 36 / 48 | Bold | `text-{brand}-600` |
+
+### 3.3 Casing rules
+
+- **Title Case** for hero headlines and major section heads.
+- **sentence case** for body copy and CTA buttons.
+- **ALL CAPS** only for marketing-page trust badges (`50+ STUDIOS`, `20+ YEARS EXPERIENCE`, `YOUR TERMS`). Never in-app, never on buttons.
+
+### 3.4 Length caps
+
+- Hero headline: ≤ 18 words
+- Section body: ≤ 25 words
+- One-liner / caption: ≤ 12 words
+- Slide hero: ≤ 12 words on screen (rest → speaker notes)
+- Slide content: ≤ 25 words on screen
+
+---
+
+## 4. Logo and wordmark
+
+- **Wordmark:** "KStoryBridge" set in the SF Pro bold. Single word, no space, capital K, capital S, capital B.
+- **Lockup color:**
+  - On white / light: `midnight-ink` (#1C1C1C).
+  - On dark: `snow-white` (#FFFFFF).
+  - On brand color (teal or coral): `snow-white`.
+  - Never on yellow. Never on a photo without a dark overlay (at least 40% opacity black).
+- **Clear space:** minimum padding around the wordmark equal to the cap-height of the "K".
+- **Minimum size:** 120px wide on screen, 0.75in / 19mm in print.
+- **Don't:** stretch, skew, recolor to anything other than ink/white, drop-shadow, outline, add a tagline lockup.
+
+> Wordmark-only is the primary identity. There is no standalone icon mark yet — don't ship one until it's been approved centrally.
+
+---
+
+## 5. Voice and tone
+
+### 5.1 Principles
+
+- **Aspirational and concrete.** "Your story on HBO" beats "unlocking opportunities."
+- **Specific numbers.** "50+ studios," "2M subscribers," "4 months not 2 weeks." Never "many," "lots," "tons."
+- **Direct address.** "Your," "You." Never "Our users," "content creators."
+- **Lead with the outcome.** What they get, not what we do.
+
+### 5.2 Audience register
+
+| Audience | Register | Example |
+| --- | --- | --- |
+| Creators | Empowerment, creative energy | "Your story deserves the global stage." |
+| Buyers | Precision, velocity, trust | "Find your next hit with AI-powered comps in 10 seconds." |
+| Dual | Balanced, outcome-first | "The bridge between Korean IP and global screens." |
+
+### 5.3 Banned words
+
+> revolutionize · disrupt · seamless · synergy · solution · ecosystem · leverage · unlock (as a verb for abstract nouns) · game-changer · next-generation · cutting-edge
+
+If you find yourself reaching for one of these, you're describing us instead of what the reader gets.
+
+### 5.4 Approved voice examples (from shipped copy)
+
+- "Find your next hit with AI."
+- "Your Korean story, on Hollywood screens."
+- "Curated. Cleared. Closed."
+- "50+ studios. 20+ years. Your terms."
+- "Four months, not two weeks." *(time-to-close contrast)*
+- "We don't sell leads. We close deals."
+
+### 5.5 From-line for email
+
+Always "KStoryBridge." Never "The KStoryBridge team," never "Hello from KStoryBridge." First line of the email is specific to the recipient — never "Hi there."
+
+---
+
+## 6. Layout principles
+
+### 6.1 Spacing
+
+Mobile-first, Tailwind defaults. `sm` 640, `md` 768, `lg` 1024, `xl` 1280.
+
+| Purpose | Tailwind |
+| --- | --- |
+| Section vertical padding | `py-12 sm:py-16 lg:py-20` |
+| Section horizontal padding | `px-4 sm:px-6 lg:px-8` |
+| Container | `max-w-7xl mx-auto` |
+| Card margin bottom | `mb-6 sm:mb-8 lg:mb-12` |
+| Card internal padding | `p-4 sm:p-6` |
+| Grid gap | `gap-4 sm:gap-6` |
+
+### 6.2 Radius
+
+| Element | Radius |
+| --- | --- |
+| Cards | `rounded-2xl` (1rem) |
+| Primary CTAs (marketing) | `rounded-full` |
+| Secondary buttons (in-product) | `rounded-md` |
+| Badges | `rounded-full` |
+| Icon boxes | `rounded-lg` |
+
+### 6.3 Shadows
+
+- **Marketing cards:** none. `shadow-none` is mandatory.
+- **Primary hero CTA:** `shadow-lg` allowed, one per section.
+- **In-product cards (dashboard):** `hover:shadow-xl` allowed.
+- **Email templates:** none. Most clients strip them.
+
+### 6.4 Card style by surface
+
+There are two card styles. Use the right one.
+
+**A. Marketing card (flat)** — landing pages, decks, social, emails:
+```
+bg-transparent border-gray-300 shadow-none rounded-2xl
+```
+
+**B. Product card (soft elevated)** — buyer dashboard, admin panels, in-app UI:
+```
+bg-white border-hanok-teal/20 rounded-2xl hover:shadow-xl transition-all duration-300
+```
+
+If you're building a marketing/external artifact, default to A. Only use B inside the authenticated product.
+
+---
+
+## 7. Motion
+
+Use motion to reward attention, not decorate.
+
+| Pattern | Use |
+| --- | --- |
+| `fade-in-up` | Hero subtitle entry |
+| `scale-in` | CTA / badge land |
+| `pulse-glow` | Attention-draw on a single primary CTA |
+
+**Rules:**
+- One animated element per viewport.
+- Honor `prefers-reduced-motion: reduce`.
+- No auto-playing videos as decoration.
+- No infinite background loops.
+- No page-level parallax.
+
+---
+
+## 8. Imagery
+
+### 8.1 Hierarchy
+
+1. **Real product screenshots** — highest priority. ~29 approved screenshots live in [`marketing/assets/producer/`](../assets/producer/) and [`marketing/assets/creator/`](../assets/creator/). Use these before generating anything new.
+2. **Approved Korean title key visuals** — webtoon/novel cover art for featured content. Rights-cleared only.
+3. **Minimal illustration** — avoid. If you must, flat line, two-color (one brand + one neutral).
+4. **Stock photography** — avoid. If unavoidable, must feature real creators/buyers in context (not laptops-on-desks generic).
+
+### 8.2 Prohibited
+
+- AI-generated people (hands, faces). Telegraphs AI-slop, undermines trust.
+- Generic "diversity" stock photo sets.
+- Korean visual clichés (hanbok, palace photos, temple shots) unless editorially justified.
+- Anything yellow.
+
+### 8.3 Korean cultural references
+
+**Good:** hanok architecture lines (the roofline inspires the logo's visual feel), warm-sand palette, subtle typographic hangul in secondary position.
+
+**Avoid:** kimchi/food emoji, K-pop visual shorthand, taegeuk/flag graphics (political), overtly "exotic" framing.
+
+---
+
+## 9. Decision tree: which color do I use?
+
+```
+Is the artifact going to a creator? ........... sunrise-coral primary
+Is the artifact going to a buyer? ............. hanok-teal primary
+Is it the homepage / About / company news? .... teal lead, coral accent
+Is it about a rights/legal/deal topic? ........ porcelain-blue accent
+Is it a Korean heritage moment? ............... warm-sand accent
+Is it an error state? ......................... red-* (product only)
+Is it the dashboard Pro badge? ................ pro-purple
+```
+
+If you'd answer "both" (creator + buyer): pick the primary recipient. If truly dual, lead teal.
+
+---
+
+## 10. Verification checklist
+
+Run through before delivering any on-brand artifact.
+
+- [ ] **No yellow** anywhere.
+- [ ] **Audience color** correct for recipient.
+- [ ] **Casing:** Title Case on heads, sentence case on body/CTA, ALL CAPS only on trust badges.
+- [ ] **Cards:** right variant (flat for marketing, elevated for product).
+- [ ] **Container** `max-w-7xl mx-auto` with gutters.
+- [ ] **Typography** SF Pro stack; `text-black` heads, `text-gray-600` body.
+- [ ] **Copy** free of banned words. Numbers are specific.
+- [ ] **Asset check:** artifact feels like the same product family as screenshots in `marketing/assets/`.
+- [ ] **Accessibility:** text contrast ≥ 4.5:1 for body, ≥ 3:1 for large text. Motion honors reduced-motion.
+
+---
+
+## 11. Source files
+
+| Purpose | File |
+| --- | --- |
+| Color hex values (canonical) | [`packages/colors/colors.ts`](../../packages/colors/colors.ts) |
+| Runtime CSS variables | [`apps/website/src/index.css`](../../apps/website/src/index.css) |
+| Internal design system rules | [`docs/active/DESIGN_SYSTEM.md`](../../docs/active/DESIGN_SYSTEM.md) |
+| AI-agent design skill | [`.claude/skills/kstorybridge-design/`](../../.claude/skills/kstorybridge-design/) |
+| Shipped reference decks | [`marketing/decks/`](../decks/) |
+| Shipped screenshots | [`marketing/assets/`](../assets/) |
+| Per-format execution specs | [`marketing/brand/specs/`](./specs/) |
+
+---
+
+## 12. Contact
+
+Questions, exceptions, or requests for new components: open a PR against this file or message the founder. Do not invent new brand tokens without a PR — the moment we have two sources of truth, we have none.

--- a/marketing/brand/specs/deck.md
+++ b/marketing/brand/specs/deck.md
@@ -1,0 +1,192 @@
+# Spec — Decks
+
+Slide decks for sales pitches, investor updates, partner meetings, conference talks. Marp (markdown), Keynote, Google Slides, or claude.ai/design briefs. Full brand rules in [`../BRAND_GUIDE.md`](../BRAND_GUIDE.md).
+
+---
+
+## Use cases and format
+
+| Deck type | Audience | Primary color | Length | Aspect |
+| --- | --- | --- | --- | --- |
+| Producer / buyer deck | Studios, streamers, production cos. | `hanok-teal` | 12–18 slides | 16:9 |
+| Creator deck | Korean authors, agents | `sunrise-coral` | 10–14 slides | 16:9 |
+| Introduction deck (neutral) | First-touch general audience | Teal lead + coral accents | 8–12 slides | 16:9 |
+| Investor deck | VCs, strategic investors | `hanok-teal` | 12–15 slides | 16:9 |
+| Conference talk | Public audience | Per audience | 20–40 slides | 16:9 |
+
+**Aspect ratio:** 16:9 (1920×1080) unless the venue demands otherwise. Never 4:3. Square only for single-frame social slides re-exported from a full deck.
+
+---
+
+## Canvas
+
+- **Slide size:** 1920 × 1080 px (or Marp's default 1280 × 720).
+- **Safe zone:** keep type and critical elements ≥ 80 px (4%) from every edge.
+- **Background:** `snow-white` (#FFFFFF) is default.
+- **Pause slides / dividers:** `porcelain-blue-50` (#F1F9F9) background.
+- **Hero cover:** either `snow-white` OR `midnight-ink` (#1C1C1C) with white type. Pick one per deck, don't mix.
+- **Never:** full-bleed gradients, photo backgrounds behind type, patterned backgrounds.
+
+---
+
+## Typography scale (on-screen)
+
+| Role | Size | Weight | Color |
+| --- | --- | --- | --- |
+| Hero cover title | 72 pt | Bold | `midnight-ink` or white |
+| Content slide title | 48 pt | Bold | `black` |
+| Section divider | 60 pt | Bold | brand color |
+| Supporting line | 28 pt | Semibold | `gray-700` |
+| Body text | 24 pt | Regular | `gray-600` |
+| Caption / source | 16 pt | Regular | `gray-500` |
+| BAN (big-ass number) | 120–180 pt | Bold | `text-{brand}-600` |
+
+**Minimum body size:** 20 pt. Below that, audiences in the back row can't read it. If your content won't fit at 20 pt, it belongs in speaker notes.
+
+---
+
+## Word caps (on-screen only)
+
+| Slide type | Cap |
+| --- | --- |
+| Hero cover | 12 words |
+| Section divider | 6 words |
+| Content slide | 25 words |
+| BAN slide | 1 number + 6-word caption |
+| Data slide | headline + 3-row summary; full table in appendix |
+
+Everything cut goes into speaker notes (HTML comments in Marp, notes field in Keynote/Slides).
+
+---
+
+## Color rules
+
+**One brand color per slide.** If the deck targets buyers, teal dominates throughout. If creators, coral. If mixed/neutral (introduction deck), lead teal and accent coral on 2–3 creator-focused slides — never switch mid-section.
+
+**Accent discipline:**
+- Max two brand colors per slide total (primary + one support).
+- Support is always `porcelain-blue` or `warm-sand`, never the opposing brand color.
+- Pure black (`#1C1C1C`) always counts as free — doesn't count against the two-color budget.
+
+**Forbidden:**
+- Yellow. Ever.
+- Rainbow charts. Use brand-color + gray for comparison.
+- More than two brand colors per slide.
+
+---
+
+## Standard slide templates
+
+### 1. Hero cover
+
+```
+┌──────────────────────────────────────┐
+│                                      │
+│                                      │
+│  KStoryBridge                        │  ← wordmark, 32pt, gray-500
+│                                      │
+│  Find your next hit                  │  ← title, 72pt bold, midnight-ink
+│  with AI.                            │
+│                                      │
+│  Hollywood's AI-powered Korean IP    │  ← subtitle, 28pt semibold, gray-700
+│  discovery engine.                   │
+│                                      │
+│                                      │
+│                              Sungho  │  ← speaker, 16pt, gray-500 (bottom-right)
+│                              Apr '26 │
+└──────────────────────────────────────┘
+```
+
+### 2. Section divider
+
+```
+┌──────────────────────────────────────┐
+│                                      │
+│                                      │
+│        01  The problem               │  ← 60pt bold, teal-600
+│                                      │
+│        Studios waste 4 months        │  ← 28pt, gray-700
+│        finding the wrong IP.         │
+│                                      │
+│                                      │
+└──────────────────────────────────────┘
+```
+
+### 3. BAN (big-ass number) slide
+
+```
+┌──────────────────────────────────────┐
+│                                      │
+│                                      │
+│            50+                        │  ← 180pt bold, teal-600
+│                                      │
+│       Hollywood studios               │  ← 32pt semibold, black
+│       currently hunting Korean IP.    │
+│                                      │
+│                                      │
+└──────────────────────────────────────┘
+```
+
+Use BANs instead of tables whenever one number tells the story. Tables belong in the appendix.
+
+### 4. Three-up (pillars)
+
+Three equal columns, each with an icon box, 20pt title, 18pt supporting line. Grid gap 48px. No card borders or shadows — these are content tiles, not UI cards.
+
+### 5. Comparison slide (before/after)
+
+Two columns. Left: "Traditional" in `red-50` wash with `red-600` small accent text. Right: "With KStoryBridge" in `green-50` wash with `green-600` accent. Body type stays gray-700 on both sides.
+
+### 6. Closing CTA
+
+One line with the offer, one primary CTA button (coral for creators, teal for buyers), email address below in gray-500. No QR code unless the deck is being projected to a room.
+
+---
+
+## Speaker notes discipline
+
+Everything the presenter will *say but not show* goes into notes. Rule of thumb: if you're reading the slide word-for-word, you're doing it wrong. Target density:
+
+- Slide body: 3–6 lines of visible text.
+- Speaker notes: 3–8 sentences of context, stat sources, transition cues.
+
+---
+
+## Imagery in decks
+
+- Product screenshots from [`marketing/assets/`](../../assets/) are always on-brand. First choice.
+- Korean title key visuals with rights-cleared status are second choice.
+- Maps, geo-graphics, stylized data viz are last resort — only when the data demands it.
+- Never: stock people-at-laptops, AI-generated faces, generic "globe" illustrations.
+
+---
+
+## Export
+
+- **Marp:** `marp --pdf deck.md` → use `--theme` pointing to `marketing/decks/theme.css` if one exists.
+- **Keynote/Slides:** export PDF with "Best" quality. File name: `KStoryBridge-{audience}-{YYMMDD}.pdf` (e.g. `KStoryBridge-producer-260422.pdf`).
+- **Font embedding:** if exporting to PDF for external sharing, embed Inter as SF Pro substitute (not every machine has SF Pro).
+
+---
+
+## Reference decks in this repo
+
+- [`marketing/decks/producer-deck.md`](../../decks/) — buyer flagship
+- [`marketing/decks/creator-deck.md`](../../decks/) — creator flagship
+- [`marketing/decks/introduction-deck.md`](../../decks/) — neutral first-touch
+
+Open these before starting a new deck — match tone, density, and cadence.
+
+---
+
+## Pre-flight checklist
+
+- [ ] 16:9 aspect, 1920×1080
+- [ ] One primary brand color for the whole deck, matched to audience
+- [ ] Every slide under its word cap (hero ≤ 12, content ≤ 25)
+- [ ] Title Case on titles, sentence case everywhere else
+- [ ] Body text ≥ 20pt
+- [ ] Speaker notes written for every content slide
+- [ ] No yellow, no rainbow charts, no stock people
+- [ ] Closing slide has one specific CTA + email
+- [ ] Exported PDF has embedded fonts

--- a/marketing/brand/specs/image.md
+++ b/marketing/brand/specs/image.md
@@ -1,0 +1,219 @@
+# Spec — Image Assets
+
+Static images for social (LinkedIn, X, Instagram, Threads), OG/share cards, display ads, press kits, event signage, in-product promo banners. Full brand rules in [`../BRAND_GUIDE.md`](../BRAND_GUIDE.md).
+
+---
+
+## Formats and sizes
+
+| Use case | Aspect | Dimensions (px) | Notes |
+| --- | --- | --- | --- |
+| LinkedIn / X feed post | 16:9 | 1920 × 1080 | Default choice for most announcements |
+| Instagram / LinkedIn square | 1:1 | 1080 × 1080 | Grid-friendly, works on all feeds |
+| Instagram / TikTok story cover | 9:16 | 1080 × 1920 | Vertical; crop-safe zone in center 80% |
+| LinkedIn cover / X header | 3:1 | 1584 × 396 (LI), 1500 × 500 (X) | Face/logo in center; test crop on mobile |
+| OG / Twitter share card | 1.91:1 | 1200 × 630 | One headline + wordmark, nothing else |
+| Email hero | 2:1 | 1200 × 600 | Inline image, no text baked in (accessibility) |
+| Display ad — leaderboard | 8:1 | 728 × 90 | Wordmark + one-line offer + CTA pill |
+| Display ad — medium rectangle | 1.2:1 | 300 × 250 | Wordmark + stat + CTA pill |
+| In-product banner | 16:3 | 1600 × 300 | Dismissable promo strip |
+| Event signage (portrait) | 2:3 | 2400 × 3600 @ 300dpi | For retractable banners, 24×36in |
+
+**File format:**
+- **PNG** for flat compositions with type, logos, UI.
+- **JPG (quality 85)** for photo-heavy images.
+- **WebP** is fine for web but always ship a PNG/JPG fallback.
+- **SVG** for the wordmark and icons only — never for compositions.
+
+**Max file size:**
+- Social posts: ≤ 8 MB (LinkedIn/IG limit).
+- OG cards: ≤ 1 MB (faster unfurl).
+- Email: ≤ 200 KB (deliverability).
+
+---
+
+## Composition rules
+
+### Grid
+
+Treat every frame as a 12-column grid with gutters. Anchor type and imagery to the grid — never freehand placement.
+
+- **1:1 and 16:9:** 12-col grid, 64 px margins, 24 px gutters.
+- **9:16:** 6-col grid, 48 px margins.
+- **Safe zone:** keep critical content (headlines, logos, faces) within the inner 80% — phone crops, Instagram preview crops, OG text overlays all eat edges.
+
+### Negative space
+
+**At least 20% of the frame is empty.** Forces focus. If you're filling corner-to-corner, you're cheating. The KSB visual signature is calm, not loud.
+
+### Type hierarchy
+
+One image = one message. Max three type elements:
+
+1. **Primary headline** — `text-6xl` equivalent (≈ 60 px on a 1080 canvas), bold, `midnight-ink`. ≤ 9 words.
+2. **Supporting line (optional)** — 24 px, semibold, `gray-700`. ≤ 12 words.
+3. **Accent line (optional)** — tiny label, 14 px, semibold, brand color. E.g. `FEATURED TITLE` or `50+ STUDIOS`.
+
+**Never:**
+- Stack three headlines.
+- Use decorative display fonts.
+- Wrap type across more than two lines.
+- Put type on top of a busy image without a dark overlay (≥ 40% black).
+
+### Color budget
+
+Max **two brand colors per image.**
+
+- Primary: audience color (teal or coral).
+- Support: `porcelain-blue`, `warm-sand`, or `midnight-ink`.
+- Grays are always free — don't count against the budget.
+
+Example combos:
+- ✅ Coral headline + warm-sand accent block + black body (creator announcement)
+- ✅ Teal CTA + porcelain-blue wash + black numbers (buyer stat card)
+- ❌ Teal + coral + porcelain-blue + sand (too many voices)
+
+---
+
+## Reusable image patterns
+
+### A. Announcement card (1:1)
+
+```
+┌──────────────────────────────┐
+│                              │
+│   KStoryBridge               │  ← wordmark top-left, 24px
+│                              │
+│                              │
+│   Your Korean story          │  ← headline, 56px bold
+│   deserves the global        │
+│   stage.                     │
+│                              │
+│   ───                        │  ← 40px coral divider
+│                              │
+│   kstorybridge.com           │  ← URL, 18px gray-500
+│                              │
+└──────────────────────────────┘
+```
+
+### B. Stat card (1:1 or 16:9)
+
+```
+┌──────────────────────────────────────┐
+│                                      │
+│   50+                                 │  ← BAN, 160px bold, teal-600
+│                                      │
+│   Hollywood studios                   │  ← caption, 28px semibold, black
+│   hunting Korean IP right now.        │
+│                                      │
+│                                      │
+│                       KStoryBridge    │
+└──────────────────────────────────────┘
+```
+
+### C. Featured-title card (9:16 story, 1:1 feed)
+
+Title key visual fills top 60%, optional dark gradient overlay at bottom, then:
+- Title name (EN) — 32px bold, white
+- Genre + format badge — 14px pill, coral or teal
+- "Available on KStoryBridge" — 16px, gray-200
+
+### D. Quote card (1:1)
+
+```
+┌──────────────────────────────┐
+│                              │
+│   "                          │  ← 96px coral quotation mark
+│                              │
+│   We closed in 5 weeks       │  ← quote, 36px semibold, black
+│   what usually takes a       │
+│   year."                     │
+│                              │
+│   — Head of Development,      │  ← attribution, 18px gray-600
+│     [Studio]                  │
+│                              │
+│   KStoryBridge                │
+└──────────────────────────────┘
+```
+
+### E. Side-by-side comparison (16:9)
+
+Two columns, `red-50` left (Traditional), `green-50` right (KStoryBridge). One icon + one headline + 2-bullet summary each. Central vertical divider in `gray-200`.
+
+---
+
+## Screenshots as hero imagery
+
+When showcasing the product, **real screenshots beat AI mockups every time.** The approved library lives in:
+
+- [`marketing/assets/producer/`](../../assets/producer/) — ~15 buyer-side screenshots
+- [`marketing/assets/creator/`](../../assets/creator/) — ~14 creator-side screenshots
+
+**Handling screenshots:**
+- Corner radius: `rounded-xl` (12 px) on the screenshot edge.
+- Drop shadow (for marketing context only, not for product UI): `shadow-2xl` equivalent (0 25px 50px -12px rgba(0,0,0,0.25)).
+- Optional browser chrome: simplified, gray-100 bar, three traffic-light dots, no URL bar content.
+- Never add fake cursors, fake annotations, fake hover states.
+
+---
+
+## Imagery and subject matter
+
+### Approved
+
+- Real product UI (screenshots)
+- Rights-cleared Korean title key visuals
+- Minimal editorial photography of real team members (founder, collaborators) — warm natural light, uncluttered background
+- Abstract geometric accents drawn from the hanok roofline (subtle, support-only)
+
+### Prohibited
+
+- AI-generated people / hands / faces
+- Stock "business team" photography
+- K-pop / idol imagery
+- Food cliché photography (kimchi, ramen, BBQ)
+- Cityscapes as decoration (Seoul skyline unless editorially relevant)
+- Hand-drawn emoji stickers
+- Anything yellow
+
+---
+
+## Accessibility
+
+- **Text contrast:** body ≥ 4.5:1, large text ≥ 3:1. Test teal-on-white (#4C9C9B on #FFF) — passes large text but fails body. Use `hanok-teal-600` or darker for body text.
+- **Alt text:** every image ships with alt text. "KStoryBridge announcement: [headline]" is the fallback.
+- **OG cards:** never bake critical info into the image alone. Repeat the headline in the post text.
+
+---
+
+## Export and naming
+
+Filename: `{purpose}-{audience}-{aspect}-{date}.png`
+
+Examples:
+- `announcement-creator-1x1-260422.png`
+- `stat-producer-16x9-260422.png`
+- `og-homepage-1.91x1-260422.png`
+
+**Delivery bundle** for a single announcement:
+- 1:1 (feed)
+- 9:16 (story)
+- 16:9 (LinkedIn/X)
+- 1.91:1 (OG/share card)
+- alt text + caption file as `.txt`
+
+---
+
+## Pre-flight checklist
+
+- [ ] Correct aspect + dimensions for destination
+- [ ] Within file-size cap for destination
+- [ ] Max two brand colors; audience color primary
+- [ ] ≥ 20% negative space
+- [ ] Type within safe zone (inner 80%)
+- [ ] Headline ≤ 9 words
+- [ ] No yellow, no AI people, no stock business photography
+- [ ] Contrast tested (body ≥ 4.5:1)
+- [ ] Wordmark visible and not distorted
+- [ ] Alt text written
+- [ ] File named per convention

--- a/marketing/brand/specs/video.md
+++ b/marketing/brand/specs/video.md
@@ -1,0 +1,220 @@
+# Spec — Video Assets
+
+Short-form social (Reels, Shorts, TikTok), explainers, product demos, sizzle reels, event loops, investor update videos. Full brand rules in [`../BRAND_GUIDE.md`](../BRAND_GUIDE.md).
+
+---
+
+## Formats and use cases
+
+| Use case | Aspect | Runtime | Destination |
+| --- | --- | --- | --- |
+| Vertical short | 9:16 | 15–60 s | Reels, Shorts, TikTok, LinkedIn mobile |
+| Social landscape | 16:9 | 30–90 s | LinkedIn, X, YouTube, website hero loop |
+| Square social | 1:1 | 15–60 s | Instagram feed, cross-platform safe |
+| Explainer / demo | 16:9 | 60–180 s | Website, email, YouTube |
+| Sizzle reel (investor, partner) | 16:9 | 60–120 s | Decks, partner meetings, fundraising |
+| Event loop (silent) | 16:9 | 20–30 s, loop | Trade-show screens, office displays |
+| Product walkthrough | 16:9 | 2–5 min | Onboarding, support, sales |
+
+**Technical specs:**
+- Resolution: **1080p minimum**, 4K for flagship assets.
+- Frame rate: **30 fps** standard, 60 fps if motion graphics demand it. No 24 fps unless shot on camera.
+- Codec: **H.264** (universal), HEVC/H.265 acceptable for web.
+- Container: **MP4**.
+- Bitrate: 10–15 Mbps for 1080p social, 25+ Mbps for flagship.
+- Audio: AAC, stereo, 48 kHz, -14 LUFS normalized (social-platform standard).
+
+---
+
+## Runtime discipline
+
+Most watch-time is earned in the first 3 seconds. Structure every video as:
+
+| Beat | Time | Purpose |
+| --- | --- | --- |
+| Hook | 0–3 s | One specific promise or question. Character/logo can appear but is not the hook. |
+| Payoff / demo | 3–?? s | Deliver on the hook. Product footage, stat, proof. |
+| CTA | final 3–5 s | One action. URL or short verb ("kstorybridge.com"). |
+
+If the video is longer than 30 s, insert a mid-roll re-hook — a second surprise, a new stat, or a pattern interrupt — every 15 s.
+
+---
+
+## Safe zones
+
+Platforms crop aggressively. Respect these zones.
+
+### 9:16 (vertical)
+
+- **UI-safe zone:** center 60% vertically (from ~16% to ~76% of frame height). Captions + UI chrome eat top and bottom.
+- **Text-safe zone:** center 70% horizontally.
+- **Logo placement:** top-left, 5% inset — avoids TikTok/IG profile bubble (bottom-right) and caption overlays.
+
+### 16:9
+
+- **Title-safe zone:** inner 90%.
+- **Action-safe:** inner 95%.
+- **Captions:** bottom 15% — don't put brand type there; it'll fight subtitles.
+
+### 1:1
+
+- **Safe zone:** inner 85%.
+- Assume the top 12% gets covered by the username on IG.
+
+---
+
+## Motion system
+
+Match the brand's calm discipline — minimal, purposeful, never decorative.
+
+### Type animation
+
+- **Entrance:** fade + 20 px rise (200 ms, ease-out). Never bounce, never flip.
+- **Exit:** fade only (150 ms).
+- **Emphasis:** scale from 100% → 104% over 400 ms, ease-in-out. One element at a time.
+- **Typing / typewriter:** allowed for hero hooks. Monospace or SF Pro; cursor blinks 2× then continues.
+
+### Lower thirds
+
+- Left-aligned, 8% from left edge, 12% from bottom.
+- Brand-color bar (2 px, audience color) on top of name line.
+- Name in SF Pro bold 36pt white; title in SF Pro regular 22pt `gray-200`.
+- Slides in from the left (200 ms), holds ≥ 3 s, slides out or cross-fades.
+
+### Transitions
+
+- **Between shots:** hard cuts. Cross-dissolves only for emotional beats (founder interview, closing).
+- **Between sections:** 200 ms fade-through-white or fade-through-black.
+- **Never:** slides, wipes, page-peels, cube transitions, zoom transitions.
+
+### Camera movement (on-product captures)
+
+- **Smooth zooms / pans:** OK at subtle speeds (< 5% of frame per second).
+- **Screen recordings:** steady, no cursor flicker. Highlight rings on click use `hanok-teal` 80% opacity, 400 ms pulse.
+- **Speed ramps:** OK for product capture (e.g. 2× during navigation, 1× during key moments). Don't ramp text moments.
+
+### Motion to avoid
+
+- Parallax scrolling backgrounds
+- Infinite spinners as "loading" stingers
+- Hand-drawn / whiteboard animations
+- 3D rotating logos
+- Glitch effects
+- Shake / earthquake on "dramatic" cuts
+
+---
+
+## Typography in video
+
+- **Stack:** SF Pro Display (falls back to Inter for non-Apple export pipelines).
+- **Never** Comic Sans, Lobster, Pacifico, or any other display font.
+
+| Role | Size (1080p canvas) | Weight | Color |
+| --- | --- | --- | --- |
+| Full-screen title | 96–140 px | Bold | `midnight-ink` or white |
+| Lower third name | 36 px | Bold | white |
+| Lower third title | 22 px | Regular | `gray-200` |
+| Stat BAN | 180–240 px | Bold | brand color |
+| Caption / subtitle | 42 px | Semibold | white with 2 px black shadow or `rgba(0,0,0,0.6)` pill |
+| End card CTA | 56 px | Bold | white on brand color |
+
+**Always caption every video.** Accessibility + 85% of social viewing is silent.
+
+- Burned-in captions for vertical social (platform subtitle rendering is inconsistent).
+- Separate `.srt` for horizontal content on YouTube/LinkedIn.
+- Caption style: white text, ≥ 40 px, with semi-opaque black pill behind each line. Never yellow captions.
+
+---
+
+## Color grading
+
+- **Untreated footage:** preferred. Don't apply Instagram filters.
+- **Correction pass:** neutral white balance, skin tones warm but natural, highlights held under 100 IRE.
+- **Brand-color integration:** introduce teal/coral through props, UI on screens, lower-third bars, and graphics — not through grade tint.
+- **Forbidden:** teal-orange grade (cliché cinematic look), heavy film-grain overlays, chromatic aberration.
+
+---
+
+## Audio
+
+- **Music:** instrumental only. No vocal tracks on explainers (fights narration). Licensed from Artlist, Musicbed, or similar. Never uncleared.
+- **Tone:** understated, modern, non-epic. Avoid "corporate uplift" tracks.
+- **Ducking:** music sits at -20 to -24 LUFS under narration (which lives at -14 to -16 LUFS).
+- **Voiceover:** one voice per video. Mic close, no room reverb, de-essed, compressed 3:1.
+- **End stinger:** max 1 s, single piano / synth chord on brand-color logo reveal. No sound-effect library stings.
+
+---
+
+## End card
+
+Every public-facing video ends with a 2–3 s card:
+
+```
+┌──────────────────────────────────────┐
+│                                      │
+│   KStoryBridge                        │  ← wordmark, 80px, black or white
+│                                      │
+│   Find your next hit with AI.         │  ← tagline, 32px semibold
+│                                      │
+│   kstorybridge.com                    │  ← URL, 40px bold, brand color
+│                                      │
+└──────────────────────────────────────┘
+```
+
+- Background: `snow-white` or `midnight-ink`.
+- One URL. One sentence. No QR codes on video unless it's an event loop.
+
+---
+
+## Thumbnail
+
+Every horizontal video needs a custom thumbnail.
+
+- 1280 × 720
+- One face (if there is one) — eye contact, not laughing.
+- One 3–5 word headline, 120px bold, matching the brand-guide image rules.
+- Wordmark bottom-right.
+- No arrows, no red circles, no shocked faces, no MrBeast-style clickbait decoration.
+
+---
+
+## File delivery
+
+**Filename:** `KSB-{usecase}-{aspect}-{YYMMDD}.mp4`
+
+Examples:
+- `KSB-reel-creator-9x16-260422.mp4`
+- `KSB-explainer-buyer-16x9-260422.mp4`
+- `KSB-sizzle-16x9-260422.mp4`
+
+**Bundle for each social launch:**
+- 9:16 master (1080 × 1920, H.264, with burned captions)
+- 16:9 master (1920 × 1080, H.264, with SRT)
+- 1:1 crop (1080 × 1080, H.264)
+- Thumbnail PNG
+- Caption file (SRT) + transcript (TXT)
+
+---
+
+## Accessibility
+
+- **Captions:** always. Burned in for vertical, SRT for horizontal.
+- **Flash / strobe:** nothing over 3 flashes per second.
+- **Motion:** for web-embedded autoplay loops, respect `prefers-reduced-motion` — ship a static poster image as the default for users who've set that preference.
+- **Color contrast:** captions ≥ 4.5:1 against content behind them. Use the black pill behind white text if the footage varies.
+
+---
+
+## Pre-flight checklist
+
+- [ ] Correct aspect + runtime for destination platform
+- [ ] Hook delivered in first 3 s
+- [ ] One clear CTA at the end
+- [ ] Safe zones respected (UI-safe 60% center for vertical)
+- [ ] Captions: burned for vertical, SRT for horizontal
+- [ ] Audio: music ducks under VO, -14 LUFS normalized
+- [ ] End card: wordmark + one URL
+- [ ] Custom thumbnail delivered
+- [ ] No yellow, no glitch effects, no 3D logo spins
+- [ ] Filename matches convention
+- [ ] Static poster image shipped for autoplay contexts

--- a/marketing/brand/specs/website.md
+++ b/marketing/brand/specs/website.md
@@ -1,0 +1,313 @@
+# Spec — Website
+
+Landing pages, microsites, marketing pages on kstorybridge.com, preview pages, partner co-branded sections. Full brand rules in [`../BRAND_GUIDE.md`](../BRAND_GUIDE.md). For in-product (authenticated dashboard) UI, see `docs/active/DESIGN_SYSTEM.md`.
+
+---
+
+## Scope
+
+| Surface | Color lead | Example |
+| --- | --- | --- |
+| Homepage | Teal lead + coral accents | `/` |
+| Buyer / producer landing | `hanok-teal` | `/buyers`, `/producers` |
+| Creator landing | `sunrise-coral` | `/creators` |
+| About / company | Teal lead | `/about` |
+| Pricing | `hanok-teal` | `/pricing` |
+| Auth redirects / stubs | Teal lead | `/signup`, `/signin` |
+| Preview (dev-only) | Per audience | `/*-preview` |
+
+---
+
+## Page architecture
+
+Every landing page follows the canonical **7-section structure** (matches shipped `BuyersPagePreview.tsx` + `CreatorsPagePreview.tsx`):
+
+1. **Hero** — headline + subline + primary CTA. Audience color.
+2. **Priority #1 showcase (30% focus)** — the one feature that sells this audience. Studio logo wall for creators; AI chatbot demo for buyers; etc.
+3. **Three pillars / guarantees** — three-card grid, equal weight.
+4. **Deep dive (25–30% focus)** — one theme in depth (rights verification, cultural translation, expert curation).
+5. **Before / After comparison** — two columns, red-50 vs green-50.
+6. **3-step process** — step badge cards. Badges are `hanok-teal` regardless of page audience (convention).
+7. **Final CTA + trust signals** — primary CTA, ✓ trust bullets, optional newsletter.
+
+**Don't invent new section types without a PR.** Cohesion across pages is the whole game.
+
+---
+
+## Layout
+
+### Container + gutters
+
+```html
+<section class="py-12 sm:py-16 lg:py-20">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <!-- content -->
+  </div>
+</section>
+```
+
+- Max width: `max-w-7xl` (1280 px).
+- Gutters: `px-4 sm:px-6 lg:px-8`.
+- Section vertical: `py-12 sm:py-16 lg:py-20`.
+
+### Grid
+
+```html
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+```
+
+- Mobile: 1 col.
+- Tablet: 2 col.
+- Desktop: 3 col (pillars) or 4 col (logo walls).
+- Gap: `gap-4 sm:gap-6`.
+
+### Breakpoints (Tailwind defaults)
+
+| Name | Width |
+| --- | --- |
+| `sm` | 640 px |
+| `md` | 768 px |
+| `lg` | 1024 px |
+| `xl` | 1280 px |
+| `2xl` | 1536 px |
+
+**Always mobile-first.** Start with the smallest-viewport layout and layer up.
+
+---
+
+## Component library
+
+### Hero
+
+```tsx
+<section className="py-20 lg:py-28 bg-gradient-to-b from-white to-porcelain-blue-50">
+  <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+    <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-midnight-ink mb-6">
+      Find your next hit with AI.
+    </h1>
+    <p className="text-lg sm:text-xl text-gray-600 mb-8 max-w-2xl mx-auto">
+      Hollywood's AI-powered Korean IP discovery engine. 50+ studios already inside.
+    </p>
+    <Button className="bg-hanok-teal hover:bg-hanok-teal-600 text-white rounded-full px-8 py-4 text-lg shadow-lg">
+      Get started
+    </Button>
+  </div>
+</section>
+```
+
+### Marketing card (flat)
+
+Always use this on marketing pages. Never `bg-white`, never shadow.
+
+```tsx
+<Card className="bg-transparent border-gray-300 shadow-none rounded-2xl">
+  <CardContent className="p-4 sm:p-6">
+    {/* content */}
+  </CardContent>
+</Card>
+```
+
+### Primary CTA (marketing)
+
+```tsx
+<Button className="bg-hanok-teal hover:bg-hanok-teal-600 text-white rounded-full px-8 py-4 text-lg font-semibold shadow-lg">
+  Find titles
+</Button>
+```
+
+Swap `hanok-teal` for `sunrise-coral` on creator pages. `rounded-full` is non-negotiable on marketing CTAs.
+
+### Secondary button
+
+```tsx
+<Button variant="outline" className="border-gray-300 hover:bg-gray-100 text-black rounded-md">
+  Learn more
+</Button>
+```
+
+### Icon box (in pillars / features)
+
+```tsx
+<div className="w-12 h-12 bg-hanok-teal/10 rounded-lg flex items-center justify-center">
+  <Sparkles className="h-6 w-6 text-hanok-teal" />
+</div>
+```
+
+### Step badge
+
+Numbered 1-2-3 in the 3-step process section. Always teal regardless of page audience.
+
+```tsx
+<div className="w-16 h-16 bg-hanok-teal text-white rounded-2xl shadow-lg flex items-center justify-center text-2xl font-bold">
+  1
+</div>
+```
+
+### Trust badge (marketing-only ALL CAPS)
+
+```tsx
+<span className="inline-block px-3 py-1 bg-porcelain-blue-100 text-porcelain-blue-700 text-xs font-semibold uppercase tracking-wider rounded-full">
+  50+ STUDIOS
+</span>
+```
+
+### Before/After comparison
+
+```tsx
+<div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+  <Card className="bg-red-50 border-gray-300 shadow-none rounded-2xl">
+    <CardContent className="p-6">
+      <span className="text-xs font-semibold text-red-600 uppercase">Traditional</span>
+      <h3 className="text-xl font-bold text-black mt-2">4 months of cold outreach</h3>
+      {/* bullets */}
+    </CardContent>
+  </Card>
+  <Card className="bg-green-50 border-gray-300 shadow-none rounded-2xl">
+    <CardContent className="p-6">
+      <span className="text-xs font-semibold text-green-600 uppercase">With KStoryBridge</span>
+      <h3 className="text-xl font-bold text-black mt-2">5 weeks to signed deal</h3>
+      {/* bullets */}
+    </CardContent>
+  </Card>
+</div>
+```
+
+### Universal header
+
+Use the existing `UniversalHeader` component. Never rebuild.
+
+- Height: 64 px desktop, 56 px mobile.
+- Background: `bg-white/80 backdrop-blur-md`, sticky.
+- Logo left (wordmark, 28 px tall).
+- Nav center on desktop, hamburger on mobile.
+- CTA right — primary, audience-color on landing pages.
+
+### Footer
+
+Use the existing `Footer` component. Contains:
+- Wordmark + 1-line company description
+- 3 column link groups (Product · Company · Legal)
+- Email capture
+- Social icons (LinkedIn, X)
+- © year, privacy, terms
+
+---
+
+## Typography on web
+
+| Role | Tailwind |
+| --- | --- |
+| Hero | `text-4xl sm:text-5xl lg:text-6xl font-bold text-midnight-ink` |
+| Section head | `text-2xl sm:text-3xl font-bold text-black` |
+| Subsection | `text-xl font-semibold text-black` |
+| Card title | `text-lg font-semibold text-black` |
+| Lead | `text-lg sm:text-xl text-gray-600` |
+| Body | `text-base text-gray-600` |
+| Caption | `text-sm text-gray-500` |
+
+---
+
+## Backgrounds and gradients
+
+| Pattern | Class | Use |
+| --- | --- | --- |
+| Default page | solid `bg-white` | Most pages |
+| Soft page | `bg-gradient-to-b from-white to-porcelain-blue-50` | Homepage, airy landing pages |
+| Warm band | `bg-gradient-to-b from-warm-sand-50 to-white` | Korean cultural / heritage sections |
+| Support section | `bg-porcelain-blue-50` | Rights / legal / deal blocks |
+| Dark CTA band | `bg-midnight-ink` | High-contrast closing CTA |
+
+**Never:** full-page gradients, animated gradients, mesh gradients, photo-as-background-with-text-on-top.
+
+---
+
+## Imagery on web
+
+- **Heroes:** real product screenshots (preferred) or rights-cleared key visuals. Drop in at `rounded-xl` with no custom border.
+- **Studio logo wall:** monochrome, sized consistently, horizontally scrolling on mobile. Source from [Supabase `/images/` bucket](https://app.supabase.com/project/dlrnrgcoguxlkkcitlpd) with fallback chain (`.png → .jpg → .svg → .webp → text`).
+- **Illustrations:** avoid. If necessary, flat line, two-color (brand + gray), never gradient.
+- **Icons:** `lucide-react` only. 24 px standard. Never mix icon libraries.
+
+---
+
+## Responsive rules
+
+- **Test breakpoints:** 375 (iPhone SE), 768 (tablet), 1024 (laptop), 1440 (desktop).
+- **Text sizes scale:** `text-2xl sm:text-3xl lg:text-4xl` pattern everywhere.
+- **Spacing scales:** `mb-6 sm:mb-8 lg:mb-12`.
+- **Grids collapse:** 3-col desktop → 2-col tablet → 1-col mobile.
+- **Touch targets:** ≥ 44 px tall on mobile (buttons, nav items).
+- **Horizontal scroll:** only on intentional elements (logo walls, category pills). Never on page body.
+
+---
+
+## Performance budget
+
+| Metric | Target |
+| --- | --- |
+| Largest Contentful Paint | ≤ 2.5 s on 4G |
+| First Input Delay | ≤ 100 ms |
+| Cumulative Layout Shift | ≤ 0.1 |
+| Page weight | ≤ 1.5 MB (excluding video) |
+| Image weight | ≤ 400 KB per image |
+| Font loading | zero webfonts (system stack) |
+
+**Image format:** AVIF preferred, WebP fallback, JPG/PNG for older clients. All hero images lazy-loaded except the above-the-fold one.
+
+---
+
+## Accessibility
+
+- **Contrast:** body text ≥ 4.5:1, large text ≥ 3:1. Teal on white passes large, fails body — use `text-hanok-teal-600` or darker for body.
+- **Keyboard nav:** every interactive element reachable via Tab. Focus rings visible (`focus:ring-2 focus:ring-hanok-teal`).
+- **Alt text:** every `<img>` has descriptive alt. Decorative images use `alt=""`.
+- **Headings:** strict hierarchy. One `h1` per page. No skipping levels.
+- **Forms:** every input labeled. Errors announced via `aria-live`.
+- **Motion:** honor `prefers-reduced-motion: reduce`. No auto-playing video with sound.
+- **Skip link:** every page has a "Skip to content" link for keyboard users.
+
+---
+
+## SEO + metadata
+
+Every page ships with:
+
+- `<title>` — ≤ 60 chars, format: `{page} · KStoryBridge`.
+- `<meta name="description">` — ≤ 160 chars, first-person outcome-led.
+- OG image — 1200 × 630, one headline, matches brand image spec.
+- `og:title` + `og:description` — can differ from SEO title/desc if social-tuned.
+- Canonical URL.
+- `hreflang` for EN/KO variants once localized content ships.
+
+---
+
+## Preview page system (internal)
+
+Dev-only preview routes live at `/{page-name}-preview` and are gated behind `import.meta.env.DEV`. See [`apps/website/PREVIEW_PAGES.md`](../../../apps/website/PREVIEW_PAGES.md) for the full system.
+
+**Rules:**
+- Preview routes never ship to production.
+- Yellow "PREVIEW MODE" banner at the top (exception to the no-yellow rule — explicitly for dev-only surface).
+- Link from preview to production for side-by-side comparison.
+
+---
+
+## Voice on web
+
+Headlines on the web are the most visible surface in the brand. They travel to social, decks, press. Follow the bank in the design skill's `voice.md` or the i18n files at `apps/website/src/i18n/locales/en/`. Don't freestyle new taglines — PR them first.
+
+---
+
+## Pre-flight checklist
+
+- [ ] 7-section structure followed (or deliberately documented exception)
+- [ ] Audience primary color correct (teal vs coral)
+- [ ] `max-w-7xl mx-auto` container, correct gutters
+- [ ] Flat marketing cards only (`bg-transparent border-gray-300 shadow-none`)
+- [ ] Primary CTA `rounded-full`, audience color, one per section
+- [ ] Responsive tested at 375 / 768 / 1024 / 1440
+- [ ] LCP ≤ 2.5 s, no webfonts loaded, images lazy-loaded
+- [ ] Alt text on every image, keyboard nav works, contrast passes
+- [ ] OG image + meta description set
+- [ ] No yellow, no mesh gradients, no stock business photography
+- [ ] Headlines match the approved voice bank


### PR DESCRIPTION
## Summary

Promotes the new public brand guide and per-format spec sheets from staging (v2) to production (main).

### Changes Included

- `12fb02ff` docs: add public brand guide and per-format spec sheets
- `0c4c6177` Merge remote-tracking branch 'origin/main' into v2

### Files Changed

- `marketing/brand/BRAND_GUIDE.md`
- `marketing/brand/specs/deck.md`
- `marketing/brand/specs/image.md`
- `marketing/brand/specs/video.md`
- `marketing/brand/specs/website.md`

### Affected Apps

| App | Files Changed | Will Auto-Deploy |
|-----|---------------|------------------|
| Dashboard | 0 | No |
| Creator | 0 | No |
| Website | 0 | No |
| Edge Functions | 0 | No |
| Migrations | 0 | No |

Docs-only change. No application code, no database migrations, no edge function changes.

### Deployment Checklist

Pre-merge:
- [x] Docs-only — no app behavior changes
- [x] No breaking API changes
- [x] No database migrations

Post-merge:
- [ ] Confirm merge completes cleanly
- [ ] No deploy verification needed (no app code touched)

### Rollback Plan

Revert this PR via GitHub if needed — no data or runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)