### PR TITLE
feat(website): publish Korean creator intro deck at /intro

### DIFF
--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -7,7 +7,7 @@
   },
   "rewrites": [
     {
-      "source": "/((?!assets|js|docs).*)",
+      "source": "/((?!assets|js|docs|intro).*)",
       "destination": "/index.html"
     }
   ]


### PR DESCRIPTION
## Summary
- Adds the bundled Marp-exported Korean creator intro deck at [apps/website/public/intro/index.html](apps/website/public/intro/index.html) (24 MB, fully self-contained — inline fonts, images, scaling, keyboard nav, print-to-PDF).
- Updates the SPA rewrite in [apps/website/vercel.json:10](apps/website/vercel.json#L10) to exclude `/intro` from the React shell fallback so the static file is served directly.
- No nav/CTA link added — the deck is intentionally a shareable URL only.

## Test plan
- [ ] Production: confirm `https://kstorybridge.com/intro` loads the deck (cover slide visible, ← → keys advance, "PDF 저장" button opens print dialog).
- [ ] Mobile (375px): confirm the deck letterboxes correctly.
- [ ] Regression: visit `/`, `/creators`, `/producers`, `/about` — confirm SPA still routes (rewrite change only adds an exclusion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)