### PR TITLE
feat(marketing): bridge slide on creator deck + Kevin bio headline rewrite

### DIFF
--- a/apps/website/src/i18n/locales/en/team.json
+++ b/apps/website/src/i18n/locales/en/team.json
@@ -2,31 +2,31 @@
   "kevin": {
     "hero": {
       "eyebrow": "Team",
-      "headlineLine1": "Few understand Korean stories",
-      "headlineLine2": "as deeply as he does.",
-      "sub": "He understands what makes Korean stories resonate — and translates them into the language of Hollywood.",
+      "headlineLine1": "Few understand the Western playbook",
+      "headlineLine2": "for Korean content like he does.",
+      "sub": "He understands what makes Korean stories resonate - and translates them into the language of Hollywood.",
       "name": "Kevin Nicklaus",
       "role": "Co-Founder & Partner, KStoryBridge",
       "portraitAlt": "Kevin Nicklaus"
     },
-    "lead": "Kevin Nicklaus has spent decades in Hollywood adapting source IP for the screen. He built a long career at The Wolper Organization at Warner Bros., rising from Director of Development to Senior Vice President of Development at a single company. He has since advised Tapas Media and RIDI / Manta on the global expansion of Korean platform IP. He is currently Executive Producer on <title>The Beginning After The End</title> — a flagship Tapas webcomic now airing as a global anime on Crunchyroll and Fuji TV.",
+    "lead": "Kevin Nicklaus has spent decades in Hollywood adapting source IP for the screen. He built a long career at The Wolper Organization at Warner Bros., rising from Director of Development to Senior Vice President of Development at a single company. He has since advised Tapas Media and RIDI / Manta on the global expansion of Korean platform IP. He is currently Executive Producer on <title>The Beginning After The End</title> - a flagship Tapas webcomic now airing as a global anime on Crunchyroll and Fuji TV.",
     "trust": {
       "eyebrow": "Trust",
-      "headlineLine1": "The world Korean creators work in",
+      "headlineLine1": "The Korean creator's world",
       "headlineLine2": "isn't new to him.",
       "intro": "Kevin is still working inside Korean platforms today.",
-      "tapasBullet": "<strong>Tapas Media</strong> (a Kakao company) — Consulting Producer",
-      "ridiBullet": "<strong>RIDI / Manta</strong> — Consulting Producer",
-      "rare": "Few American producers advise two Korean platforms at once. For him, Korean IP isn't a passing trend — it's daily work.",
-      "rights": "He already understands — through the work itself — the environment Korean creators write in and the position they stand from. So when a Korean creator's first question at KStoryBridge is — <emph>\"What happens to my rights?\"</emph> — the answer is already built into where he begins.",
+      "tapasBullet": "<strong>Tapas Media</strong> (a Kakao company) - Consulting Producer",
+      "ridiBullet": "<strong>RIDI / Manta</strong> - Consulting Producer",
+      "rare": "Few American producers advise two Korean platforms at once. For him, Korean IP isn't a passing trend - it's daily work.",
+      "rights": "He already understands - through the work itself - the environment Korean creators write in and the position they stand from. So when a Korean creator's first question at KStoryBridge is - <emph>\"What happens to my rights?\"</emph> - the answer is already built into where he begins.",
       "logos": "Tapas (Kakao) · RIDI · Manta"
     },
     "expertise": {
       "eyebrow": "Expertise",
       "headlineLine1": "A lifetime spent",
-      "headlineLine2": "on a single craft — adaptation",
-      "p1": "At The Wolper Organization, the production company at Warner Bros., Kevin spent decades focused on one thing — <strong>taking stories that already exist and bringing them to a new screen.</strong>",
-      "p2": "Almost everything he has worked on has been <strong>IP with existing source material</strong>. Novels, comics, true stories, classics — the forms vary, but the common thread is one. <strong>Taking stories that already exist and re-drawing them on screen.</strong> His expertise comes down to a single word — <strong>adaptation</strong>.",
+      "headlineLine2": "on a single craft - adaptation",
+      "p1": "At The Wolper Organization, the production company at Warner Bros., Kevin spent decades focused on one thing - <strong>taking stories that already exist and bringing them to a new screen.</strong>",
+      "p2": "Almost everything he has worked on has been <strong>IP with existing source material</strong>. Novels, comics, true stories, classics - the forms vary, but the common thread is one. <strong>Taking stories that already exist and re-drawing them on screen.</strong> His expertise comes down to a single word - <strong>adaptation</strong>.",
       "p3": "His development network reaches the major American and global studios and streamers. When a Korean story heads abroad, the people he already knows are the ones in the room.",
       "logos": "Warner Bros. · Amazon · Netflix · FX"
     },
@@ -37,15 +37,15 @@
       "intro": "Kevin's current concurrent projects:",
       "items": {
         "tbate": {
-          "title": "<title>The Beginning After The End</title> — Executive Producer",
+          "title": "<title>The Beginning After The End</title> - Executive Producer",
           "description": "Tapas webcomic → global anime on Crunchyroll / Fuji TV. Season 2 currently airing."
         },
         "junjiIto": {
-          "title": "<title>Junji Ito's Bloodsucking Darkness</title> — Executive Producer",
+          "title": "<title>Junji Ito's Bloodsucking Darkness</title> - Executive Producer",
           "description": "Produced by Fangoria Studios. The first English-language live-action film based on a Junji Ito work."
         },
         "sandstone": {
-          "title": "Sandstone Artists — Partner & Head of Production",
+          "title": "Sandstone Artists - Partner & Head of Production",
           "description": "Advising Tapas and RIDI / Manta in parallel."
         },
         "microdrama": {
@@ -58,11 +58,11 @@
     "closing": {
       "line1Part1": "Kevin has spent his life",
       "line1Part2": "moving writers' stories to the screen.",
-      "line2Part1": "Now he is looking for his next one —",
+      "line2Part1": "Now he is looking for his next one -",
       "line2Part2": "among Korean writers."
     },
     "cta": {
-      "headlineLine1": "Your work, and the possibilities it carries —",
+      "headlineLine1": "Your work, and the possibilities it carries -",
       "headlineLine2": "let's explore them with KStoryBridge.",
       "body": "It starts with a conversation about the work.",
       "button": "▶ Request a meeting",

--- a/apps/website/src/i18n/locales/ko/team.json
+++ b/apps/website/src/i18n/locales/ko/team.json
@@ -2,8 +2,8 @@
   "kevin": {
     "hero": {
       "eyebrow": "Team",
-      "headlineLine1": "한국 이야기의 진가를",
-      "headlineLine2": "누구보다 깊이 아는 사람.",
+      "headlineLine1": "한국 콘텐츠가 할리우드에서 통하는 문법을",
+      "headlineLine2": "누구보다 잘 아는 사람.",
       "sub": "한국 이야기의 매력을 제대로 이해하고, 할리우드의 언어로 옮깁니다.",
       "name": "Kevin Nicklaus",
       "role": "Co-Founder & Partner, KStoryBridge",
@@ -15,18 +15,18 @@
       "headlineLine1": "한국 창작자의 입장은,",
       "headlineLine2": "그에게 새로운 주제가 아닙니다",
       "intro": "Kevin은 지금도 한국 플랫폼 안에서 일하고 있습니다.",
-      "tapasBullet": "<strong>Tapas Media</strong> (Kakao 산하) — Consulting Producer",
-      "ridiBullet": "<strong>RIDI / Manta</strong> — Consulting Producer",
+      "tapasBullet": "<strong>Tapas Media</strong> (Kakao 산하) - Consulting Producer",
+      "ridiBullet": "<strong>RIDI / Manta</strong> - Consulting Producer",
       "rare": "두 한국 플랫폼을 동시에 자문해온 미국 producer는 거의 없습니다. 그에게 한국 IP는 새로운 트렌드가 아니라 일상입니다.",
-      "rights": "한국 창작자가 어떤 환경에서 작품을 만들고, 어떤 입장에 서 있는지 — 그는 매일의 작업 안에서 이미 알고 있습니다. 그래서 KStoryBridge에서 한국 작가가 가장 먼저 묻는 질문 — <emph>\"권리는 어떻게 되나요\"</emph> — 에 대한 답이, 그가 출발하는 자리에 이미 들어 있습니다.",
+      "rights": "한국 창작자가 어떤 환경에서 작품을 만들고, 어떤 입장에 서 있는지 - 그는 매일의 작업 안에서 이미 알고 있습니다. 그래서 KStoryBridge에서 한국 작가가 가장 먼저 묻는 질문 - <emph>\"권리는 어떻게 되나요\"</emph> - 에 대한 답이, 그가 출발하는 자리에 이미 들어 있습니다.",
       "logos": "Tapas (Kakao) · RIDI · Manta"
     },
     "expertise": {
       "eyebrow": "전문성",
       "headlineLine1": "평생 한 가지 일에",
-      "headlineLine2": "깊이 파고들었습니다 — 각색(adaptation)",
-      "p1": "Kevin은 Warner Bros. 계열의 The Wolper Organization에서 한 가지 일에 오래 집중해왔습니다 — <strong>이미 존재하는 이야기를 새로운 화면 위로 옮기는 일.</strong>",
-      "p2": "그가 다뤄온 작품들은 거의 모두 <strong>원작이 있는 IP</strong>입니다. 소설, 만화, 실화, 클래식 — 형태는 다양하지만 공통점은 하나입니다. <strong>이미 존재하는 이야기를 영상으로 다시 그리는 일.</strong> 그의 전문 분야는 한 단어로 정리됩니다 — <strong>각색(adaptation)</strong>.",
+      "headlineLine2": "깊이 파고들었습니다 - 각색(adaptation)",
+      "p1": "Kevin은 Warner Bros. 계열의 The Wolper Organization에서 한 가지 일에 오래 집중해왔습니다 - <strong>이미 존재하는 이야기를 새로운 화면 위로 옮기는 일.</strong>",
+      "p2": "그가 다뤄온 작품들은 거의 모두 <strong>원작이 있는 IP</strong>입니다. 소설, 만화, 실화, 클래식 - 형태는 다양하지만 공통점은 하나입니다. <strong>이미 존재하는 이야기를 영상으로 다시 그리는 일.</strong> 그의 전문 분야는 한 단어로 정리됩니다 - <strong>각색(adaptation)</strong>.",
       "p3": "그의 개발 네트워크는 미국과 글로벌 메이저 스튜디오·스트리머와 닿아 있습니다. 한국의 이야기가 글로벌로 향할 때, 그가 이미 아는 사람들이 그 자리에 있습니다.",
       "logos": "Warner Bros. · Amazon · Netflix · FX"
     },
@@ -45,7 +45,7 @@
           "description": "Fangoria Studios 제작. Junji Ito 작품 최초의 영어 실사 영화화."
         },
         "sandstone": {
-          "title": "Sandstone Artists — Partner & Head of Production",
+          "title": "Sandstone Artists - Partner & Head of Production",
           "description": "Tapas, RIDI / Manta 자문 동시 진행."
         },
         "microdrama": {

--- a/marketing/bios/kevin-bio-ko.md
+++ b/marketing/bios/kevin-bio-ko.md
@@ -1,10 +1,10 @@
-# KStoryBridge — Kevin Nicklaus Bio (Korean)
+# KStoryBridge - Kevin Nicklaus Bio (Korean)
 
 ## Audience
 Korean creators (원작가 + 소규모 IP 스튜디오) evaluating Kevin / KStoryBridge as a Hollywood partner. Read after the service intro deck or as a standalone "Why Kevin" page.
 
 ## Page goal
-Balance authority with narrative — establish credentials but lean toward making the reader want to work with him.
+Balance authority with narrative - establish credentials but lean toward making the reader want to work with him.
 
 ## Voice
 3rd person. Calm, specific, premium, non-salesy. Same tonal direction as `marketing/decks/kstorybridge-creator-deck-v6.md`.
@@ -12,9 +12,9 @@ Balance authority with narrative — establish credentials but lean toward makin
 ## Page structure (top → bottom)
 1. Hero
 2. Lead paragraph
-3. Section — 신뢰
-4. Section — 전문성
-5. Section — 실행력
+3. Section - 신뢰
+4. Section - 전문성
+5. Section - 실행력
 6. Closing
 7. CTA
 
@@ -32,8 +32,8 @@ Sungho bio is a separate file (TBD); this page can link to it from the closing o
 Co-Founder & Partner, KStoryBridge
 
 **Headline:**
-**한국 이야기의 진가를  
-누구보다 깊이 아는 사람.**
+**한국 콘텐츠가 할리우드에서 통하는 문법을  
+누구보다 잘 아는 사람.**
 
 **Sub:**
 한국 이야기의 매력을 제대로 이해하고, 할리우드의 언어로 옮깁니다.
@@ -54,28 +54,28 @@ Kevin Nicklaus는 할리우드에서 오랜 시간 원작 기반 IP를 영상으
 
 Kevin은 지금도 한국 플랫폼 안에서 일하고 있습니다.
 
-- **Tapas Media** (Kakao 산하) — Consulting Producer
-- **RIDI / Manta** — Consulting Producer
+- **Tapas Media** (Kakao 산하) - Consulting Producer
+- **RIDI / Manta** - Consulting Producer
 
 두 한국 플랫폼을 동시에 자문해온 미국 producer는 거의 없습니다. 그에게 한국 IP는 새로운 트렌드가 아니라 일상입니다.
 
-한국 창작자가 어떤 환경에서 작품을 만들고, 어떤 입장에 서 있는지 — 그는 매일의 작업 안에서 이미 알고 있습니다. 그래서 KStoryBridge에서 한국 작가가 가장 먼저 묻는 질문 — *"권리는 어떻게 되나요"* — 에 대한 답이, 그가 출발하는 자리에 이미 들어 있습니다.
+한국 창작자가 어떤 환경에서 작품을 만들고, 어떤 입장에 서 있는지 - 그는 매일의 작업 안에서 이미 알고 있습니다. 그래서 KStoryBridge에서 한국 작가가 가장 먼저 묻는 질문 - *"권리는 어떻게 되나요"* - 에 대한 답이, 그가 출발하는 자리에 이미 들어 있습니다.
 
-**Logo strip (section footer):** Tapas (Kakao) · RIDI · Manta — monochrome
+**Logo strip (section footer):** Tapas (Kakao) · RIDI · Manta - monochrome
 
 ---
 
 ## Section 4. 전문성
 
-**Section header:** 평생 한 가지 일에 깊이 파고들었습니다 — 각색(adaptation)
+**Section header:** 평생 한 가지 일에 깊이 파고들었습니다 - 각색(adaptation)
 
-Kevin은 Warner Bros. 계열의 The Wolper Organization에서 한 가지 일에 오래 집중해왔습니다 — 이미 존재하는 이야기를 새로운 화면 위로 옮기는 일.
+Kevin은 Warner Bros. 계열의 The Wolper Organization에서 한 가지 일에 오래 집중해왔습니다 - 이미 존재하는 이야기를 새로운 화면 위로 옮기는 일.
 
-그가 다뤄온 작품들은 거의 모두 **원작이 있는 IP**입니다. 소설, 만화, 실화, 클래식 — 형태는 다양하지만 공통점은 하나입니다. **이미 존재하는 이야기를 영상으로 다시 그리는 일.** 그의 전문 분야는 한 단어로 정리됩니다 — **각색(adaptation)**.
+그가 다뤄온 작품들은 거의 모두 **원작이 있는 IP**입니다. 소설, 만화, 실화, 클래식 - 형태는 다양하지만 공통점은 하나입니다. **이미 존재하는 이야기를 영상으로 다시 그리는 일.** 그의 전문 분야는 한 단어로 정리됩니다 - **각색(adaptation)**.
 
 그의 개발 네트워크는 미국과 글로벌 메이저 스튜디오·스트리머와 닿아 있습니다. 한국의 이야기가 글로벌로 향할 때, 그가 이미 아는 사람들이 그 자리에 있습니다.
 
-**Logo strip (section footer):** Warner Bros. · Amazon · Netflix · FX — monochrome
+**Logo strip (section footer):** Warner Bros. · Amazon · Netflix · FX - monochrome
 
 ---
 
@@ -91,10 +91,10 @@ Kevin이 현재 동시 진행하고 있는 일들:
 - **《Junji Ito's Bloodsucking Darkness》 Executive Producer**  
   Fangoria Studios 제작. Junji Ito 작품 최초의 영어 실사 영화화.
 
-- **Sandstone Artists** — Partner & Head of Production  
+- **Sandstone Artists** - Partner & Head of Production  
   Tapas, RIDI / Manta 자문 동시 진행.
 
-- **마이크로드라마 영역 확장** — Crazy Maple Studio (ReelShort 모회사) Media Consultant로 협업. 짧은 호흡의 글로벌 콘텐츠 시장으로 영역 확장 중.
+- **마이크로드라마 영역 확장** - Crazy Maple Studio (ReelShort 모회사) Media Consultant로 협업. 짧은 호흡의 글로벌 콘텐츠 시장으로 영역 확장 중.
 
 Kevin이 한 작품을 챔피언한다는 것은, 그 작품이 **그가 이미 다른 IP들로 증명하고 있는 경로**에 합류한다는 뜻입니다.
 
@@ -124,32 +124,32 @@ Kevin이 한 작품을 챔피언한다는 것은, 그 작품이 **그가 이미 
 ## Design Direction
 
 ### 톤 / 무드 (deck v6와 직접 연결)
-- Hero & CTA: **v5 Global Stage** — cinematic, confident, premium
-- Body sections: **v2 Warm Publishing** — warm, calm, creator-protective
-- Credit lists & proof: **editorial-tech clarity** — restrained, structured
+- Hero & CTA: **v5 Global Stage** - cinematic, confident, premium
+- Body sections: **v2 Warm Publishing** - warm, calm, creator-protective
+- Credit lists & proof: **editorial-tech clarity** - restrained, structured
 
 ### 컬러 팔레트
 - 배경: warm off-white (#F8F5F0 정도)
-- 본문: near-black (#1A1A1A) — 순흑 회피
-- 어센트: muted gold 또는 burnt orange — 할리우드 warmth
+- 본문: near-black (#1A1A1A) - 순흑 회피
+- 어센트: muted gold 또는 burnt orange - 할리우드 warmth
 - Hero overlay: 인물 위 dark gradient (legibility)
 
 ### 타이포그래피
-- Display (헤드라인): Pretendard SemiBold / Nanum Myeongjo — 한글 명조 + 영문 serif 페어링
+- Display (헤드라인): Pretendard SemiBold / Nanum Myeongjo - 한글 명조 + 영문 serif 페어링
 - Body: Pretendard / Noto Sans KR + Inter / SF Pro
 - 작품명 (《Roots》, 《Bates Motel》): light italic
 - Hero 헤드라인: 두 줄까지, 70px+
 - 본문 컬럼 폭 max 640–720px (잡지 한 컬럼 느낌)
 
 ### 사진
-- Kevin: 첨부 portrait — slight desaturation, warm tonal grade
+- Kevin: 첨부 portrait - slight desaturation, warm tonal grade
 - 저장 경로: `marketing/bios/assets/kevin-portrait.jpg`
 - 카메라 살짝 비낀 각도, corporate stock 회피
 
 ### 페이싱 / 스크롤
 - 섹션 사이 vertical space 넉넉 (스크린 높이 60–80%)
 - 헤드라인 등장 시 0.6초 fade-in
-- 패럴랙스 사용하지 않음 — 차분함 유지
+- 패럴랙스 사용하지 않음 - 차분함 유지
 
 ### Sticky mini-nav (선택)
 - 우상단 작게: Kevin · 미팅 신청
@@ -164,7 +164,7 @@ Kevin이 한 작품을 챔피언한다는 것은, 그 작품이 **그가 이미 
 - 스플래시 애니메이션
 - 헤드라인 타이프라이터 효과
 - 크레딧 옆 아이콘
-- 본문 prose에 bullet point — 크레딧·리스트에만
+- 본문 prose에 bullet point - 크레딧·리스트에만
 - 비디오 오토플레이
 - 로고 grid 잔치 (로고는 입증 도구, 도배 도구 아님)
 
@@ -193,7 +193,7 @@ Kevin이 한 작품을 챔피언한다는 것은, 그 작품이 **그가 이미 
 ## What to cut first if it feels long
 1. Microdrama bullet in Section 5 (only if KStoryBridge doesn't actively serve that path)
 2. "최근 개발 네트워크" sentence in Section 4 (the WBTV/Amazon/Netflix list)
-3. Lead paragraph (Section 2) — Section 3 onward can carry the load
+3. Lead paragraph (Section 2) - Section 3 onward can carry the load
 
 ---
 
@@ -201,9 +201,9 @@ Kevin이 한 작품을 챔피언한다는 것은, 그 작품이 **그가 이미 
 
 These were flagged by fact-check but cannot be resolved from public sources:
 
-1. **Sandstone "founding partner" status** — currently softened to "파트너로 합류." Sandstone's team page lists him only as "Partner" (Tammy Hunt is the publicly named co-founder). Confirm with Kevin if "founding partner" is accurate, then restore.
-2. **New Line Cinema connection** — original copy referenced an upcoming New Line *Salem's Lot*, but that film released on Max Oct 3, 2024 and Kevin has no public credit on it. Removed pending confirmation of any current New Line dev project.
-3. **Crazy Maple Studio (ReelShort) — September 2025 start date** — only sourced from his LinkedIn (unreachable). Kept as written; confirm or hedge to "2025년부터."
-4. **LinkedIn "Top Skills: Comic Book IP"** (Section 4 paragraph after credits list) — cannot verify without LinkedIn. Consider rephrasing to a verifiable equivalent: *"그의 IMDb 자기소개에는 RIDI/Manta·Tapas의 consulting producer로서 'comic book IP 기반 각색'이 핵심 활동으로 명시되어 있습니다."*
-5. **Junji Ito superlative** ("작품 최초의 영어 실사 영화화") — appears only in Kevin's own IMDb mini-bio, not in Variety or other trade press. Plausible but no third-party confirmation. Kept as written.
-6. **Crunchyroll proof URL** (Asset Notes line 198) — that URL is only the Crunchyroll-only announcement. The Fuji TV broadcast claim is true but should swap proof to [Wikipedia TBATE](https://en.wikipedia.org/wiki/The_Beginning_After_the_End) or Anime News Network for a stronger source.
+1. **Sandstone "founding partner" status** - currently softened to "파트너로 합류." Sandstone's team page lists him only as "Partner" (Tammy Hunt is the publicly named co-founder). Confirm with Kevin if "founding partner" is accurate, then restore.
+2. **New Line Cinema connection** - original copy referenced an upcoming New Line *Salem's Lot*, but that film released on Max Oct 3, 2024 and Kevin has no public credit on it. Removed pending confirmation of any current New Line dev project.
+3. **Crazy Maple Studio (ReelShort) - September 2025 start date** - only sourced from his LinkedIn (unreachable). Kept as written; confirm or hedge to "2025년부터."
+4. **LinkedIn "Top Skills: Comic Book IP"** (Section 4 paragraph after credits list) - cannot verify without LinkedIn. Consider rephrasing to a verifiable equivalent: *"그의 IMDb 자기소개에는 RIDI/Manta·Tapas의 consulting producer로서 'comic book IP 기반 각색'이 핵심 활동으로 명시되어 있습니다."*
+5. **Junji Ito superlative** ("작품 최초의 영어 실사 영화화") - appears only in Kevin's own IMDb mini-bio, not in Variety or other trade press. Plausible but no third-party confirmation. Kept as written.
+6. **Crunchyroll proof URL** (Asset Notes line 198) - that URL is only the Crunchyroll-only announcement. The Fuji TV broadcast claim is true but should swap proof to [Wikipedia TBATE](https://en.wikipedia.org/wiki/The_Beginning_After_the_End) or Anime News Network for a stronger source.

--- a/marketing/decks/kstorybridge-creator-intro-EN-V1(4:26:2026).md
+++ b/marketing/decks/kstorybridge-creator-intro-EN-V1(4:26:2026).md
@@ -26,7 +26,7 @@ Meaningful connections are still rare.**
 
 You have fans. You have traction.
 But the chance to be seen by international
-producers — and adapted for screen — is still
+producers - and adapted for screen - is still
 hard to come by.
 
 **What your story needs now is a partner
@@ -44,17 +44,17 @@ on the creator's shoulders**
 
 Three-card grid:
 
-**01 · Cold email — rarely read**
+**01 · Cold email - rarely read**
 One in hundreds gets opened.
 Language and context barriers
 mean most go unanswered.
 
-**02 · Agents — hard to reach, costly to hire**
+**02 · Agents - hard to reach, costly to hire**
 Access alone is difficult,
 fees are high,
 and there's little room to negotiate.
 
-**03 · Film markets — millions of won, no guarantees**
+**03 · Film markets - millions of won, no guarantees**
 Booth fees are steep,
 no one promises eyes on your work,
 and every follow-up is on you.
@@ -84,11 +84,11 @@ We don't stop at registration.
 **We carry your work into actual reviews
 and follow-up conversations.**
 
-Right column — three numbered items:
+Right column - three numbered items:
 
-**01. Reframed for the global format** — pitch deck, comps, format fit
-**02. Direct line to decision-makers** — execs at Netflix, Disney, Amazon, Sony
-**03. Transparent progress reports** — reviewers, feedback, next steps shared regularly
+**01. Reframed for the global format** - pitch deck, comps, format fit
+**02. Direct line to decision-makers** - execs at Netflix, Disney, Amazon, Sony
+**03. Transparent progress reports** - reviewers, feedback, next steps shared regularly
 
 ---
 
@@ -100,26 +100,53 @@ and understands Hollywood deeply**
 
 Three trust cards:
 
-**Trust — We start on the Korean creator's side**
+**Trust - We start on the Korean creator's side**
 We start from the rights and the position
 of the Korean author.
 You don't have to give up your rights
 to show your work to the world.
 
-**Expertise — Decades of Hollywood project development**
+**Expertise - Decades of Hollywood project development**
 Kevin is the Executive Producer
 of Crunchyroll's animated series
 *The Beginning After The End*.
 
-**Experience — A team that's worked global IP firsthand**
-Netflix, Wolper/WB, RIDI, Tapas —
+**Experience - A team that's worked global IP firsthand**
+Netflix, Wolper/WB, RIDI, Tapas -
 we've handled global IP at the source.
 We understand both Korean and global markets.
 
 ---
 
-## Slide 7. How Hollywood producers see your work
-*Eyebrow: 05 · How Hollywood producers see your work*
+## Slide 7. The two-way bridge
+*Eyebrow: 05 · The two-way bridge*
+
+**Protecting the work and
+reaching the world is
+the same job**
+
+Approached only from the Korean side, the work is hard
+to render in the language a US executive can actually
+receive. Approached only from the American side, the
+central conceit gets taken and the details that make
+the work itself get lost.
+
+KStoryBridge looks at both.
+**We protect what makes the work itself,**
+**and translate only what needs to land elsewhere.**
+
+> On a recent Korean-source adaptation for the US
+> market, we kept the storyline far more intact than
+> the author expected - while making the casting and
+> budget calls (the kind original authors don't think
+> about) that get a project actually greenlit.
+
+**Visual note:** v2 Warm Publishing treatment. Two-column diagram on the right - left column "what makes the work itself," right column "the receiving market's language," joined by a soft bridge stroke. Pull-quote in a quieter weight, framed as an illustrative example.
+
+---
+
+## Slide 8. How Hollywood producers see your work
+*Eyebrow: 06 · How Hollywood producers see your work*
 
 **This is what your work
 looks like to a Hollywood producer**
@@ -129,22 +156,22 @@ The core information and appeal are organized
 **so a producer can grasp and evaluate it quickly.**
 
 - A synopsis they can read at a glance
-- AI comps analysis showing market position instantly
-- Format fit and target market — analysis from a development lens
+- AI comps analysis - anchored to projects executives already recognize as wins
+- Format fit and target market - analysis from a development lens
 - A structure that leads to actual reviews and follow-ups
 
 **Visual layout:** the right side shows a thumbnail of the full producer-facing page on the left with three highlighted zones (teal / coral / teal), connected by dashed arrows to three larger slice cards on the right:
 
-- **Synopsis** — readable in seconds
-- **AI Comps** — comparable titles
-- **Format Fit** — development lens
+- **Synopsis** - readable in seconds
+- **AI Comps** - comps tied to executive mandates
+- **Format Fit** - development lens
 
 **Proof source:** `Does Love Need a Translator?` producer-facing detail page screenshot, sliced into three highlighted sections.
 
 ---
 
-## Slide 8. How the pitching works
-*Eyebrow: 06 · How the pitching works*
+## Slide 9. How the pitching works
+*Eyebrow: 07 · How the pitching works*
 
 **A step-by-step process
 to bring your work to market
@@ -177,24 +204,24 @@ at the formal meeting with decision-makers.
 
 ---
 
-## Slide 9. Who's using KStoryBridge
-*Eyebrow: 07 · Who's using KStoryBridge*
+## Slide 10. Who's using KStoryBridge
+*Eyebrow: 08 · Who's using KStoryBridge*
 
 **Top Hollywood producers are reviewing
 their next titles on KStoryBridge**
 
-[Studio logo wall — Netflix, Walt Disney Studios, Sony Pictures, Crunchyroll, Amazon Studios, Warner Bros, Paramount, 50+ Hollywood studios and global streamers]
+[Studio logo wall - Netflix, Walt Disney Studios, Sony Pictures, Crunchyroll, Amazon Studios, Warner Bros, Paramount, 50+ Hollywood studios and global streamers]
 
 KStoryBridge helps US and global producers
 **review Korean IP the way they're used to reviewing material.**
 
-What matters isn't being seen by many — it's **being seen properly by the right people.**
+What matters isn't being seen by many - it's **being seen properly by the right people.**
 
 **Proof source:** customer / producer logos from `https://kstorybridge.com/creators`
 
 ---
 
-## Slide 10. CTA
+## Slide 11. CTA
 **It's time for your story
 to meet the world.**
 
@@ -213,13 +240,13 @@ Link: https://kstorybridge.com/creators
 ## Assembly Notes
 
 ### Screenshot choices
-- Slide 7: use the `Does Love Need a Translator?` producer detail page
+- Slide 8: use the `Does Love Need a Translator?` producer detail page
 - Show the FULL page as a small thumbnail on the left with three zones highlighted (Synopsis / AI Comps / Format Fit)
 - Connect each zone with a dashed arrow to a larger detail-slice card on the right
 - Each detail slice gets a single pill callout (no body copy on the bubble)
 
 ### Logo proof
-- Slide 9 uses one clean logo grid image (`assets/studio-logos.png`)
+- Slide 10 uses one clean logo grid image (`assets/studio-logos.png`)
 - Wrapped in a soft white card on the cream page
 - Used as proof, not decoration
 
@@ -232,15 +259,16 @@ Every slide should feel:
 - non-salesy
 
 ### What to cut first if it feels long
-1. second paragraph on slide 7
+1. second paragraph on slide 8
 2. last line of slide 3
-3. remove pitch-step 3 ("Pre-qualified interest") on slide 8 if a 3-step flow reads cleaner
+3. remove pitch-step 3 ("Pre-qualified interest") on slide 9 if a 3-step flow reads cleaner
 
 ### Structure changes from earlier draft
 - Slide 2 image now half-bleeds to match slide 1 (was a 600×600 framed card)
 - Slide 4 transition headline reordered: "expect to review" line precedes "deeply understands"
-- Slide 7 proof layout switched from "screenshot + 3 callouts" to "page thumbnail + arrows + 3 detail slices"
-- Slide 8 added — full pitching-process flow (4 steps) was previously implicit
-- Producers/logos slide moved to slide 9 (was 8); CTA is now slide 10
+- Slide 7 added - "The two-way bridge" makes the protect-and-translate value prop explicit (per Kevin's feedback). Subsequent slides shifted down by one; eyebrow numbers re-sequenced.
+- Slide 8 (was 7) proof layout switched from "screenshot + 3 callouts" to "page thumbnail + arrows + 3 detail slices"
+- Slide 9 (was 8) added - full pitching-process flow (4 steps) was previously implicit
+- Producers/logos slide is slide 10 (was 9); CTA is now slide 11
 - Logo on every slide is the wordmark only ("KStoryBridge"), no K tile
 - PDF export button + checklist modal added to every slide for in-deck PDF saving

--- a/marketing/decks/kstorybridge-creator-intro-V1(4:26:2026).md
+++ b/marketing/decks/kstorybridge-creator-intro-V1(4:26:2026).md
@@ -1,0 +1,266 @@
+# KStoryBridge Creator Deck v6
+
+## Audience
+Korean creators evaluating whether KStoryBridge is a trustworthy way to present their work to US and global producers.
+
+## Design Direction
+- Cover / transition / CTA: v5 Global Stage
+- Empathy and trust slides: v2 Warm Publishing
+- Proof slides: restrained editorial-tech clarity
+
+## Slide 1. Cover
+**이제 당신의 스토리가
+더 큰 세상과 만날 차례입니다**
+
+한국 스토리텔러를 위한 KStoryBridge의 제안
+
+**Visual note:** half-bleed warm illustration on the right (Korean creator's window framing a Hollywood horizon), toned down and softly edged into the cream page so the headline carries the slide.
+
+---
+
+## Slide 2. 현실 공감
+*Eyebrow: 01 · 현실 공감*
+
+**훌륭한 스토리들은 많이 있지만,
+의미있는 연결은 아직 부족합니다**
+
+팬도 있고 반응도 있습니다.
+하지만 해외 업계에 작품이 소개되고
+영상화되는 기회는 많지 않습니다.
+
+**지금 여러분의 훌륭한 이야기에 필요한 건
+제대로된 연결을 도와줄 파트너입니다.**
+
+**Visual note:** half-bleed creator-at-desk illustration on the right, mirroring slide 1's treatment (toned down, soft inner edge fading into the page).
+
+---
+
+## Slide 3. 왜 기존 방식이 아쉬울까
+*Eyebrow: 02 · 왜 기존 방식이 아쉬울까*
+
+**지금의 방식들은
+창작자에게 너무 많은 부담이 됩니다**
+
+Three-card grid:
+
+**01 · 콜드메일 - 거의 읽히지 않는 콜드메일**
+수백 통 중 한 통.
+언어와 맥락의 벽 앞에서
+대부분은 답 없이 끝납니다.
+
+**02 · 에이전트 - 연락도 어렵고 비용도 큰 에이전트**
+접근부터 쉽지 않고,
+비용 부담도 큽니다.
+협상의 여지가 좁아집니다.
+
+**03 · 필름 마켓 - 한 번에 수백만 원, 보장은 없는 마켓**
+참가비는 큰데
+누가 봐줄지는 알 수 없고,
+후속도 혼자 감당해야 합니다.
+
+좋은 작품이 있어도, **기회를 찾기는 쉽지 않습니다.**
+
+---
+
+## Slide 4. 전환
+**지금 필요한 건,
+
+해외 제작자들이 원하는 방식으로 *검토받을 수 있게*
+당신의 작품을 *정확히 이해하고*
+도와주는 *파트너*입니다**
+
+**Visual note:** centered headline only, porcelain background, key phrases highlighted in teal.
+
+---
+
+## Slide 5. KStoryBridge가 하는 일
+*Eyebrow: 03 · KStoryBridge가 하는 일*
+
+**한국의 스토리들이 글로벌 시장에서
+제대로 검토받게 만듭니다**
+
+등록에서 끝나지 않고,
+**실제 검토와 후속 대화로 이어지게 만듭니다.**
+
+Right column - three numbered items:
+
+**01. 글로벌 포맷으로 재구성** - 피치덱, Comps, Format Fit
+**02. 결정권자에게 직접 연결** - 넷플릭·디즈니·아마존·소니 담당자
+**03. 진행 과정의 투명한 공유** - 검토자·피드백·다음 단계를 정기 보고
+
+---
+
+## Slide 6. 왜 KStoryBridge인가
+*Eyebrow: 04 · 왜 KStoryBridge인가*
+
+**한국 창작자들의 편에서 일하면서
+할리우드를 깊이 이해하는 든든한 파트너입니다**
+
+Three trust cards:
+
+**신뢰 · Trust - 한국 작가의 편에서 출발합니다**
+한국 작가의 권리와 입장에서 시작합니다.
+권리를 양도하지 않아도,
+작품을 세계에 보여드릴 수 있습니다.
+
+**전문성 · Expertise - 오랜 할리우드 프로젝트 개발 경험**
+Kevin은 Crunchyroll 애니메이션
+《The Beginning After The End》의
+Executive Producer입니다.
+
+**경험 · Experience - 글로벌 IP를 직접 다뤄온 팀**
+Netflix, Wolper/WB, RIDI, Tapas 등에서
+글로벌 IP를 직접 다뤘습니다.
+한국과 글로벌 시장 양쪽을 모두 이해합니다.
+
+---
+
+## Slide 7. 양방향의 다리
+*Eyebrow: 05 · 양방향의 다리*
+
+**작품을 지키는 일과
+세계에 닿게 만드는 일은
+같은 작업입니다**
+
+한국식으로만 접근하면, 미국 제작자들이
+이해할 수 있는 문화적 언어로 풀어내기 어렵습니다.
+미국식으로만 접근하면, 핵심 컨셉만 가져가고
+작품을 위대하게 만드는 디테일을 잃기 쉽습니다.
+
+KStoryBridge는 양쪽 모두를 들여다보고 이어줍니다.
+**원작의 본질은 지키고,**
+**해외 시장이 받아들일수 있게 다듬습니다.**
+
+> 최근 한국 원작을 미국 시장용 트리트먼트로 옮기면서,
+> 원작자도 놀랄 방식으로 스토리라인을 그대로 지켰습니다.
+> 동시에 캐스팅과 예산 같은 제작 현실을 고려해서 원작자라면
+> 떠올리지 못했을 각색의 방향을 잡아서 진행시켰습니다.
+
+**Visual note:** v2 Warm Publishing treatment. 우측에 두 컬럼 다이어그램 - 좌측 "원작의 본질," 우측 "해외 시장의 언어," 두 컬럼을 잇는 부드러운 브릿지 선. 풀쿼트는 본문 아래에 가벼운 무게로, 사례가 아닌 예시로 명확히 프레이밍.
+
+---
+
+## Slide 8. 할리우드 제작자들에게 작품을 소개하는 방식
+*Eyebrow: 06 · 할리우드 제작자들에게 작품을 소개하는 방식*
+
+**할리우드 제작자들은
+당신의 작품을 이렇게 보게 됩니다**
+
+KStoryBridge에서는 작품이 단순히 등록되는 데서 끝나지 않습니다.
+프로듀서가 빠르게 이해하고 검토할 수 있도록
+**핵심 정보와 매력이 더 분명하게 정리**됩니다.
+
+- 한눈에 읽히는 시놉시스
+- AI 비교작 분석 - 할리우드 임원이 "성공"으로 인식하는 작품과의 연결고리
+- 포맷 적합도 · 타겟 마켓 같은 개발 관점 분석
+- 실제 검토와 후속 대화로 이어지는 구조
+
+**Visual layout:** the right side shows a thumbnail of the full producer-facing page on the left with three highlighted zones (teal / coral / teal), connected by dashed arrows to three larger slice cards on the right:
+
+- **Synopsis** - 한눈에 읽힙니다
+- **AI Comps** - 할리우드 임원의 mandate와 맞닿는 비교작
+- **Format Fit** - 개발 관점 분석
+
+**Proof source:** `Does Love Need a Translator?` producer-facing detail page screenshot, sliced into three highlighted sections.
+
+---
+
+## Slide 9. 피칭은 이렇게 진행됩니다
+*Eyebrow: 07 · 피칭은 이렇게 진행됩니다*
+
+**작품을 시장에
+제대로 선보이는
+단계별 과정입니다**
+
+그저 등록하고 기다리는 게 아닙니다.
+덱 제작부터 미팅 진행까지
+**한 작품을 끝까지 책임**지고 끌고 갑니다.
+
+Four-step vertical flow:
+
+**01. 피치덱 직접 제작**
+Kevin의 30년 할리우드 경험을 바탕으로
+작품에 맞는 피치덱을 **직접 제작**합니다.
+
+**02. 맞춤형 피치 전략**
+스튜디오와 제작사의 **mandate(제작 방향)**를
+고려해 어디로, 어떻게 가져갈지 설계합니다.
+
+**03. 관심도 사전 확인**
+직접 미팅과 콜을 통해
+**실제 관심이 있는 곳**만 추려냅니다.
+
+**04. 공식 피치 미팅 진행**
+의사결정권자와의 공식 미팅에서
+피치를 **직접 진행**합니다.
+
+---
+
+## Slide 10. 누가 KStoryBridge를 사용하고 있을까
+*Eyebrow: 08 · 누가 KStoryBridge를 사용하고 있을까*
+
+**유수의 할리우드 제작자들이 그들의 다음 작품을
+KStoryBridge에서 검토하고 있습니다**
+
+[Studio logo wall - Netflix, Walt Disney Studios, Sony Pictures, Crunchyroll, Amazon Studios, Warner Bros, Paramount, 50+ Hollywood studios and global streamers]
+
+KStoryBridge는 미국과 글로벌 시장의 프로듀서들이
+**익숙한 방식으로 한국 IP를 검토할 수 있게** 돕습니다.
+
+중요한 건 많이 보여지는 것이 아니라, **적절한 담당자에게 제대로 보여지는 것입니다.**
+
+**Proof source:** customer / producer logos from `https://kstorybridge.com/creators`
+
+---
+
+## Slide 11. CTA
+**이제 당신의 스토리가
+세계와 만날 시간입니다!**
+
+그 시작을 저희가 함께 고민해드립니다.
+작품의 가능성에 대한 **대화를 원하세요?**
+
+▶ **이메일로 연락하기**
+partners@kstorybridge.com (클릭하면 복사됨)
+
+링크: https://kstorybridge.com/creators
+
+**Visual note:** ink (dark) background, full-bleed CTA, primary + ghost button pair.
+
+---
+
+## Assembly Notes
+
+### Screenshot choices
+- Slide 8: use the `Does Love Need a Translator?` producer detail page
+- Show the FULL page as a small thumbnail on the left with three zones highlighted (Synopsis / AI Comps / Format Fit)
+- Connect each zone with a dashed arrow to a larger detail-slice card on the right
+- Each detail slice gets a single pill callout (no body copy on the bubble)
+
+### Logo proof
+- Slide 10 uses one clean logo grid image (`assets/studio-logos.png`)
+- Wrapped in a soft white card on the cream page
+- Used as proof, not decoration
+
+### Tone check
+Every slide should feel:
+- calm
+- specific
+- creator-protective
+- premium
+- non-salesy
+
+### What to cut first if it feels long
+1. second paragraph on slide 8
+2. last line of slide 3
+3. remove pitch-step 3 ("관심도 사전 확인") on slide 9 if a 3-step flow reads cleaner
+
+### Structure changes from earlier draft
+- Slide 2 image now half-bleeds to match slide 1 (was a 600×600 framed card)
+- Slide 4 transition headline reordered: "검토받을 수 있게" line precedes "정확히 이해하고"
+- Slide 7 added - "양방향의 다리" makes the protect-and-translate value prop explicit (per Kevin's feedback). Subsequent slides shifted down by one; eyebrow numbers re-sequenced.
+- Slide 8 (was 7) proof layout switched from "screenshot + 3 callouts" to "page thumbnail + arrows + 3 detail slices"
+- Slide 9 (was 8) added - full pitching-process flow (4 steps) was previously implicit
+- Producers/logos slide is slide 10 (was 9); CTA is now slide 11
+- Logo on every slide is the wordmark only ("KStoryBridge"), no K tile
+- PDF export button + checklist modal added to every slide for in-deck PDF saving


### PR DESCRIPTION
## Summary

- **Creator intro deck (KO + EN):** inserts new slide 7 "양방향의 다리 / The two-way bridge" naming the protect-and-translate value prop explicitly (per Kevin's feedback that the deck implied dual-fluency but never named it). Tightens the AI Comps slice from generic "comparable titles" to "comps tied to executive mandates." Renumbers slides 8–11 and updates assembly notes.
- **Kevin bio (`/team/kevin` page + source markdown):** replaces hero headline in both Korean (`한국 콘텐츠가 할리우드에서 통하는 문법을 / 누구보다 잘 아는 사람.`) and English (`Few understand the Western playbook / for Korean content like he does.`) to lead with the same dual-fluency frame as the deck's bridge slide. Trust-section EN headline tightened to fix a line-wrap regression.
- **Typography pass:** em-dashes (—) replaced with hyphens (-) across both deck files and the Kevin bio (ko.md + i18n) for consistent dash style.

## Files changed

- `marketing/decks/kstorybridge-creator-intro-V1(4:26:2026).md` (KO deck)
- `marketing/decks/kstorybridge-creator-intro-EN-V1(4:26:2026).md` (EN deck)
- `marketing/bios/kevin-bio-ko.md` (KO bio source)
- `apps/website/src/i18n/locales/ko/team.json` (live KO copy on /team/kevin)
- `apps/website/src/i18n/locales/en/team.json` (live EN copy on /team/kevin)

## Test plan

- [ ] Visit \`/team/kevin\` on staging in both locales — confirm hero headline reads as expected and no section headlines have stranded-word line wraps
- [ ] Re-read both deck files end-to-end and confirm new slide 7 reads as Kevin intended
- [ ] Render decks to PDF (Marp) and visually check the new slide's two-column diagram and pull-quote layout
- [ ] Send updated deck to Kevin for sign-off before sharing with creators

🤖 Generated with [Claude Code](https://claude.com/claude-code)