### PR TITLE
feat(dashboard): free-signup auth copy + Format Fit mobile fix

### DIFF
--- a/apps/dashboard/src/components/format-fit/FormatFitDetailPanel.tsx
+++ b/apps/dashboard/src/components/format-fit/FormatFitDetailPanel.tsx
@@ -147,7 +147,7 @@ export function FormatFitDetailPanel({ titleId, className = '' }: FormatFitDetai
         </div>
 
         {/* Format Cards — click to select */}
-        <div className="grid grid-cols-5 gap-3 mb-6">
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-2 sm:gap-3 mb-6">
           {formats.map((format) => {
             const score = scores[format];
             const isBest = format === bestFormat;
@@ -157,15 +157,15 @@ export function FormatFitDetailPanel({ titleId, className = '' }: FormatFitDetai
               <button
                 key={format}
                 onClick={() => setSelectedFormat(format === selectedFormat ? null : format)}
-                className={`p-3 rounded-xl border text-center transition-all cursor-pointer ${getCardBorder(score, isSelected, isBest)}`}
+                className={`p-2 sm:p-3 rounded-xl border text-center transition-all cursor-pointer ${getCardBorder(score, isSelected, isBest)}`}
               >
                 <div className="flex justify-center mb-2">
-                  <Icon icon={FORMAT_ICONS[format]} className={`h-8 w-8 ${isSelected ? 'text-[#4C9C9B]' : 'text-gray-500'}`} />
+                  <Icon icon={FORMAT_ICONS[format]} className={`h-6 w-6 sm:h-8 sm:w-8 ${isSelected ? 'text-[#4C9C9B]' : 'text-gray-500'}`} />
                 </div>
-                <p className={`text-sm font-medium mb-1 leading-tight ${isSelected ? 'text-gray-900' : 'text-gray-600'}`}>
+                <p className={`text-xs sm:text-sm font-medium mb-1 leading-tight ${isSelected ? 'text-gray-900' : 'text-gray-600'}`}>
                   {FORMAT_DISPLAY_NAMES[format]}
                 </p>
-                <p className={`text-2xl font-bold ${getScoreColor(score)}`}>
+                <p className={`text-xl sm:text-2xl font-bold ${getScoreColor(score)}`}>
                   {score}%
                 </p>
                 {isBest && (
@@ -182,7 +182,7 @@ export function FormatFitDetailPanel({ titleId, className = '' }: FormatFitDetai
         {selectedFormat && analysis && (
           <div className="border border-gray-200 rounded-xl p-5 bg-gray-50/50">
             {/* Title row */}
-            <div className="flex items-center justify-between mb-4">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-0 mb-4">
               <div className="flex items-center gap-3">
                 <div className="p-2 rounded-lg bg-[#4C9C9B]/10">
                   <Icon icon={FORMAT_ICONS[selectedFormat]} className="h-6 w-6 text-[#4C9C9B]" />
@@ -192,7 +192,7 @@ export function FormatFitDetailPanel({ titleId, className = '' }: FormatFitDetai
                   <p className="text-sm text-gray-500">{FORMAT_DESCRIPTIONS[selectedFormat]}</p>
                 </div>
               </div>
-              <div className="text-right">
+              <div className="text-left sm:text-right">
                 <span className={`text-3xl font-bold ${getScoreColor(scores[selectedFormat])}`}>
                   {scores[selectedFormat]}%
                 </span>
@@ -219,7 +219,7 @@ export function FormatFitDetailPanel({ titleId, className = '' }: FormatFitDetai
             )}
 
             {/* Strengths & Challenges */}
-            <div className="grid grid-cols-2 gap-4 mb-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
               {analysis.strengths && analysis.strengths.length > 0 && (
                 <div>
                   <h5 className="text-sm font-semibold text-emerald-700 mb-2 flex items-center gap-1">

--- a/apps/dashboard/src/pages/auth/SignIn.tsx
+++ b/apps/dashboard/src/pages/auth/SignIn.tsx
@@ -204,7 +204,8 @@ export default function SignIn() {
               className="text-hanok-teal hover:text-hanok-teal/80 font-medium"
             >
               Sign up here
-            </Link>
+            </Link>{' '}
+            (it's free)
           </div>
         </CardContent>
       </Card>

--- a/apps/dashboard/src/pages/auth/SignUp.tsx
+++ b/apps/dashboard/src/pages/auth/SignUp.tsx
@@ -182,7 +182,7 @@ export default function SignUp() {
         <CardHeader className="space-y-1 pb-6">
           <CardTitle className="text-3xl font-bold text-midnight-ink">Producer Sign Up</CardTitle>
           <CardDescription className="text-base text-midnight-ink-600">
-            Create your producer account
+            Create your free producer account
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">


### PR DESCRIPTION
## Summary

Two small dashboard changes — copy tweak on the auth pages, and a responsive fix on the title detail page's Format Fit Analysis section.

| Commit | Subject |
|--------|---------|
| `ae4e26c2` | feat(dashboard): emphasize free signup on auth pages |
| `3daedd6d` | fix(dashboard): make Format Fit Analysis section mobile-friendly |

### What's changing

**`/signin` + `/signup`** ([SignIn.tsx](apps/dashboard/src/pages/auth/SignIn.tsx), [SignUp.tsx](apps/dashboard/src/pages/auth/SignUp.tsx))
- Signin footer now reads: `Don't have a producer account? Sign up here (it's free)` — `(it's free)` appended after the existing teal `Sign up here` link.
- Signup card subtitle: `Create your producer account` → `Create your free producer account`.

**Title detail / Format Fit Analysis** ([FormatFitDetailPanel.tsx](apps/dashboard/src/components/format-fit/FormatFitDetailPanel.tsx))
- 5-format card row was hardcoded to `grid-cols-5`, squishing on phones. Now `grid-cols-2 sm:grid-cols-3 md:grid-cols-5` with mobile-tightened gap.
- Card internals tightened on mobile: padding `p-3 → p-2 sm:p-3`, icons `h-8 w-8 → h-6 w-6 sm:h-8 sm:w-8`, label `text-sm → text-xs sm:text-sm`, score `text-2xl → text-xl sm:text-2xl`.
- Selected-format header row: stacks on mobile (`flex-col`) with side-by-side from `sm:` up; percentage block aligns left on mobile, right on desktop.
- Strengths & Challenges grid: `grid-cols-2` → `grid-cols-1 md:grid-cols-2` so each list reads full width on mobile.
- Dimension Breakdown 2-col grid intentionally left alone (cells fit at 375px).

Pure className-only changes for the responsive fix; no JSX restructure, no new components, no new imports.

### Affected apps

| App | Files changed | Auto-deploy |
|-----|---------------|-------------|
| Dashboard | 3 | Yes (Vercel dashboard-prod) |
| Website | 0 | — |
| Creator | 0 | — |

### Database changes

None.

## Test plan

**Auth copy**
- [ ] `/signin` — verify the trailing `(it's free)` renders in the same gray text right after the teal `Sign up here` link.
- [ ] `/signup` — verify the card subtitle reads `Create your free producer account` (under the `Producer Sign Up` title).

**Format Fit mobile**
- [ ] Open any title detail page (`/buyers/titles/<title_id>`) and resize DevTools to:
  - **375×667 (iPhone SE)** — 5-format row shows 2 cards per line, all percentages readable, no horizontal scroll.
  - **414×896 (iPhone 11 Pro Max)** — same as above, more comfortable.
  - **768×1024 (iPad portrait)** — 3-card row.
  - **1024+ desktop** — original 5-in-a-row preserved (no regression).
- [ ] Tap each format card at mobile width to expand the detail panel:
  - Header (icon+title and percentage) stacks vertically with no overlap.
  - Strengths and Challenges sit one above the other.
  - Dimension Breakdown 2-col grid still fits each cell without label truncation.

## Rollback

Single-PR revert via GitHub if anything regresses. All changes are className/copy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)