### PR TITLE
fix(title-intelligence): unblock Naver novel / Ridibooks / Bomtoon scrapers

### DIFF
--- a/apps/creator/src/pages/tools/TitleInvestigator.tsx
+++ b/apps/creator/src/pages/tools/TitleInvestigator.tsx
@@ -59,15 +59,17 @@ function parseUrl(url: string): ParsedUrl | null {
       }
     }
 
-    // Naver Series: series.naver.com/comic/detail.series?productNo=XXX
+    // Naver Series: series.naver.com/(comic|novel)/detail.series?productNo=XXX
     if (parsed.hostname === 'series.naver.com') {
       const productNo = parsed.searchParams.get('productNo');
       if (productNo) {
+        const subKindMatch = parsed.pathname.match(/^\/(comic|novel)\//);
         return {
           platform: 'naver_series',
           platformId: productNo,
           originalUrl: trimmedUrl,
           valid: true,
+          ...(subKindMatch ? { subKind: subKindMatch[1] as 'comic' | 'novel' } : {}),
         };
       }
     }
@@ -147,9 +149,10 @@ function parseUrl(url: string): ParsedUrl | null {
       }
     }
 
-    // Bomtoon: bomtoon.com/comic/ep_list/{slug}
+    // Bomtoon: bomtoon.com/detail/{slug} (current) or
+    //          bomtoon.com/comic/ep_list/{slug} (legacy, still resolves)
     if (parsed.hostname === 'www.bomtoon.com' || parsed.hostname === 'bomtoon.com') {
-      const pathMatch = parsed.pathname.match(/\/comic\/ep_list\/([^/?]+)/);
+      const pathMatch = parsed.pathname.match(/^\/(?:detail|comic\/ep_list)\/([^/?]+)/);
       if (pathMatch) {
         return {
           platform: 'bomtoon',

--- a/packages/tools/src/services/intelligenceService.ts
+++ b/packages/tools/src/services/intelligenceService.ts
@@ -60,12 +60,14 @@ export const COLLECTIBLE_FIELDS: CollectibleField[] = [
 const PLATFORM_PATTERNS: Record<SupportedPlatform, RegExp> = {
   // Naver Webtoon - supports /webtoon/, /challenge/, /bestChallenge/ sections
   naver_webtoon: /comic\.naver\.com\/(?:webtoon|challenge|bestChallenge)\/list\?titleId=(\d+)/,
-  naver_series: /series\.naver\.com\/comic\/detail\.series\?productNo=(\d+)/,
+  naver_series: /series\.naver\.com\/(?:comic|novel)\/detail\.series\?productNo=(\d+)/,
   kakao: /page\.kakao\.com\/content\/(\d+)|page\.kakao\.com\/.*seriesId=(\d+)/,
   kakao_webtoon: /webtoon\.kakao\.com\/content\/[^/]+\/(\d+)/,
   manta: /manta\.net\/.*seriesId=(\d+)/,
   ridibooks: /ridibooks\.com\/books\/(\d+)/,
-  bomtoon: /bomtoon\.com\/series\/(\d+)/,
+  // Bomtoon canonical detail path is /detail/{slug}; older /comic/ep_list/{slug}
+  // URLs still resolve to the same SPA shell so we accept both.
+  bomtoon: /bomtoon\.com\/(?:detail|comic\/ep_list)\/([A-Za-z0-9_-]+)/,
   unknown: /^$/,
 };
 
@@ -100,12 +102,22 @@ export function parseUrl(url: string): ParsedUrl {
     if (match) {
       // Find the first non-undefined capture group
       const platformId = match.slice(1).find((g) => g !== undefined) || null;
-      return {
+      const parsed: ParsedUrl = {
         platform: platform as SupportedPlatform,
         platformId,
         originalUrl: trimmedUrl,
         valid: true,
       };
+      // Naver Series serves /comic/ and /novel/ off the same productNo
+      // namespace but with different DOMs. Capture which path it is so the
+      // scraper builds the right fetch URL.
+      if (platform === 'naver_series') {
+        const subKindMatch = trimmedUrl.match(/series\.naver\.com\/(comic|novel)\//);
+        if (subKindMatch) {
+          parsed.subKind = subKindMatch[1] as 'comic' | 'novel';
+        }
+      }
+      return parsed;
     }
   }
 
@@ -167,6 +179,7 @@ export async function collectIntelligenceByUrls(
           platform: u.platform,
           platformId: u.platformId,
           originalUrl: u.originalUrl,
+          ...(u.subKind ? { subKind: u.subKind } : {}),
         })),
         collectedBy: userEmail,
         contentType: request.contentType,

--- a/packages/tools/src/types/intelligence.ts
+++ b/packages/tools/src/types/intelligence.ts
@@ -25,6 +25,10 @@ export interface ParsedUrl {
   originalUrl: string;
   valid: boolean;
   error?: string;
+  // Naver Series has two sub-paths: /comic/ and /novel/. Both use the same
+  // productNo namespace but render different DOMs; the scraper needs to know
+  // which one to fetch.
+  subKind?: 'comic' | 'novel';
 }
 
 // =====================================================================

--- a/supabase/functions/title-intelligence/index.ts
+++ b/supabase/functions/title-intelligence/index.ts
@@ -74,6 +74,25 @@ function isUrlBasedRequest(body: any): body is UrlBasedRequest {
   return Array.isArray(body.urls) && body.urls.length > 0
 }
 
+/**
+ * Map titles.content_format values (snake_case, e.g. 'web_novel') to the
+ * intelligence_titles.type CHECK constraint set ('webtoon', 'webnovel',
+ * 'light_novel', 'manga', 'mixed'). Values outside the constraint fall
+ * back to 'mixed' so the INSERT never trips the check.
+ */
+const INTELLIGENCE_TYPE_MAP: Record<string, string> = {
+  webtoon: 'webtoon',
+  web_novel: 'webnovel',
+  webnovel: 'webnovel',
+  light_novel: 'light_novel',
+  manga: 'manga',
+  mixed: 'mixed',
+}
+function normalizeContentType(input: string | undefined | null): string {
+  if (!input) return 'webtoon'
+  return INTELLIGENCE_TYPE_MAP[input] || 'mixed'
+}
+
 // Source category mapping
 const SOURCE_CATEGORIES: Record<string, string> = {
   'naver': 'official_platform',
@@ -214,7 +233,7 @@ async function handleUrlBasedCollection(supabase: any, body: UrlBasedRequest) {
       original_title_ko: null,  // Will be populated from scraper results
       original_title_en: null,
       slug: tempSlug,
-      type: contentType || 'webtoon',
+      type: normalizeContentType(contentType),
       original_language: 'ko',
       primary_genres: [],
     })
@@ -574,7 +593,7 @@ async function handleLegacyCollection(supabase: any, body: LegacyIntelligenceReq
         original_title_ko: titleNameInput,
         original_title_en: titleNameEn || null,
         slug: slug + '-' + Date.now(),  // Ensure unique slug
-        type: contentType || 'webtoon',
+        type: normalizeContentType(contentType),
         original_language: 'ko',
         primary_genres: [],
       })

--- a/supabase/functions/title-intelligence/index.ts
+++ b/supabase/functions/title-intelligence/index.ts
@@ -55,6 +55,9 @@ interface UrlBasedRequest {
     platform: 'naver_webtoon' | 'naver_series' | 'kakao' | 'kakao_webtoon' | 'manta' | 'ridibooks' | 'bomtoon'
     platformId: string
     originalUrl: string
+    // Naver Series ships comics and novels on the same productNo namespace
+    // but different paths. Default 'comic' when omitted (backward compat).
+    subKind?: 'comic' | 'novel'
   }>
   collectedBy: string
   contentType?: string
@@ -254,10 +257,11 @@ async function handleUrlBasedCollection(supabase: any, body: UrlBasedRequest) {
           break
 
         case 'naver_series':
-          // Use productNo directly with Naver Series scraper (with retry)
+          // Use productNo directly with Naver Series scraper (with retry).
+          // subKind tells the scraper whether to fetch /comic/ or /novel/.
           scraperResult = await withRetry(
-            () => scrapeNaverSeries(urlInfo.platformId),
-            { operationName: `Naver Series scrape (${urlInfo.platformId})`, maxRetries: 2, baseDelayMs: 2000 }
+            () => scrapeNaverSeries(urlInfo.platformId, urlInfo.subKind || 'comic'),
+            { operationName: `Naver Series scrape (${urlInfo.subKind || 'comic'}/${urlInfo.platformId})`, maxRetries: 2, baseDelayMs: 2000 }
           )
           break
 

--- a/supabase/functions/title-intelligence/scrapers/bomtoon.ts
+++ b/supabase/functions/title-intelligence/scrapers/bomtoon.ts
@@ -119,10 +119,12 @@ export async function scrapeBomtoon(slugOrUrl: string): Promise<BomtoonData> {
 
     console.log(`[Bomtoon] Using slug: ${slug}`)
     result.data.slug = slug
-    result.data.platform_url = `https://www.bomtoon.com/comic/ep_list/${slug}`
+    result.data.platform_url = `https://www.bomtoon.com/detail/${slug}`
 
-    // Fetch HTML
-    const url = `https://www.bomtoon.com/comic/ep_list/${slug}`
+    // Fetch HTML — /detail/ is the current canonical path. The legacy
+    // /comic/ep_list/{slug} URL still resolves to the same SPA shell, but
+    // /detail/ is what bomtoon.com currently redirects users to.
+    const url = `https://www.bomtoon.com/detail/${slug}`
     const response = await fetch(url, { headers: HEADERS })
 
     if (!response.ok) {
@@ -192,8 +194,10 @@ function extractSlug(input: string): string | null {
     return trimmed
   }
 
-  // bomtoon.com URL pattern: /comic/ep_list/{slug}
-  const bomtoonMatch = trimmed.match(/bomtoon\.com\/comic\/ep_list\/([^/?]+)/)
+  // bomtoon.com URL — accept both current /detail/{slug} and legacy
+  // /comic/ep_list/{slug} paths. Query strings (e.g. ?porch=tw1386) are
+  // ignored since they're tracking-only and don't affect content lookup.
+  const bomtoonMatch = trimmed.match(/bomtoon\.com\/(?:detail|comic\/ep_list)\/([^/?#]+)/)
   if (bomtoonMatch) {
     return bomtoonMatch[1]
   }
@@ -202,18 +206,47 @@ function extractSlug(input: string): string | null {
 }
 
 /**
- * Extract data from embedded JSON in the page
- * Bomtoon embeds JSON data in the page for SEO/hydration
+ * Extract data from Bomtoon's embedded __NEXT_DATA__.
+ *
+ * Bomtoon's /detail/ pages are a Next.js SPA shell; the only server-side
+ * payload with real content data is __NEXT_DATA__.props.pageProps.openGraphData,
+ * which carries title / synopsis / creators / tags / isAdult / etc.
+ *
+ * (Prior implementation scraped these via raw regex over the HTML; that was
+ * brittle because string values containing escaped quotes or commas could
+ * break the patterns. Parsing the JSON properly is more reliable.)
  */
 function extractFromEmbeddedJson(html: string, result: BomtoonData): boolean {
   let extracted = false
 
-  // Look for JSON patterns in the HTML
-  // Pattern: "title":"죽은자를 상대하는 방법(완결)"
-  const titleMatch = html.match(/"title"\s*:\s*"([^"]+)"/)
-  if (titleMatch) {
-    let title = titleMatch[1]
-    // Check if title indicates completion
+  const startMarker = '<script id="__NEXT_DATA__" type="application/json">'
+  const endMarker = '</script>'
+  const startIdx = html.indexOf(startMarker)
+  if (startIdx === -1) {
+    console.log(`[Bomtoon] __NEXT_DATA__ not found`)
+    return false
+  }
+  const jsonStart = startIdx + startMarker.length
+  const jsonEnd = html.indexOf(endMarker, jsonStart)
+  if (jsonEnd === -1) return false
+
+  let nextData: any
+  try {
+    nextData = JSON.parse(html.substring(jsonStart, jsonEnd))
+  } catch (err) {
+    console.log(`[Bomtoon] __NEXT_DATA__ parse error:`, err)
+    return false
+  }
+
+  const pageProps = nextData?.props?.pageProps
+  if (!pageProps) return false
+
+  const og = pageProps.openGraphData || {}
+
+  // Title — strip "(완결)" suffix and use it as a completion signal.
+  const rawTitle: string | undefined = og.title || pageProps.title
+  if (rawTitle && typeof rawTitle === 'string') {
+    let title = rawTitle
     if (title.includes('(완결)')) {
       result.data.completed = true
       title = title.replace('(완결)', '').trim()
@@ -222,65 +255,73 @@ function extractFromEmbeddedJson(html: string, result: BomtoonData): boolean {
     extracted = true
   }
 
-  // Pattern: "creators":"곽병진"
-  const creatorsMatch = html.match(/"creators"\s*:\s*"([^"]+)"/)
-  if (creatorsMatch) {
-    result.data.author = creatorsMatch[1]
-    result.data.artist = creatorsMatch[1] // Same person for this platform
+  // Creators string — comma-separated for multi-author works (e.g.
+  // "징망츄, 사앙"). First entry → author, second → artist.
+  if (typeof og.creators === 'string' && og.creators.trim()) {
+    const names = og.creators
+      .split(',')
+      .map((n: string) => n.trim())
+      .filter((n: string) => n.length > 0)
+    if (names[0]) {
+      result.data.author = names[0]
+      extracted = true
+    }
+    if (names[1]) {
+      result.data.artist = names[1]
+      extracted = true
+    } else if (names[0]) {
+      // Single creator — mirror to artist (same person does both, common
+      // on this platform).
+      result.data.artist = names[0]
+    }
+  }
+
+  // Synopsis — comes from openGraphData.synopsis (NOT the og:description
+  // meta tag, which is a generic platform tagline).
+  if (typeof og.synopsis === 'string' && og.synopsis.trim()) {
+    result.data.synopsis_kr = og.synopsis
     extracted = true
   }
 
-  // Pattern: "synopsis":"잡아 먹히는 공포 속에서..."
-  const synopsisMatch = html.match(/"synopsis"\s*:\s*"([^"]+)"/)
-  if (synopsisMatch) {
-    // Unescape JSON string
-    let synopsis = synopsisMatch[1]
-    synopsis = synopsis.replace(/\\n/g, '\n').replace(/\\"/g, '"').replace(/\\\\/g, '\\')
-    result.data.synopsis_kr = synopsis
-    extracted = true
-  }
-
-  // Pattern: "tags":"판타지,드라마,공포·스릴러,현대물,피폐물,상처남"
-  const tagsMatch = html.match(/"tags"\s*:\s*"([^"]+)"/)
-  if (tagsMatch) {
-    const tagsStr = tagsMatch[1]
-    const tags = tagsStr.split(',').map(t => t.trim()).filter(t => t.length > 0)
+  // Tags / genre — comma-separated list, first 3 entries form the genre
+  // hint (e.g. "BL,현대물,캠퍼스물").
+  if (typeof og.tags === 'string' && og.tags.trim()) {
+    const tags = og.tags
+      .split(',')
+      .map((t: string) => t.trim())
+      .filter((t: string) => t.length > 0)
     if (tags.length > 0) {
       result.data.tags = tags
-      // First tag is usually the main genre
       result.data.genre = tags.slice(0, 3)
       extracted = true
     }
   }
 
-  // Pattern: "imagePath":"https://image.balcony.studio/ko/co_thumbnail/5401/death_man^m.webp"
-  const imageMatch = html.match(/"imagePath"\s*:\s*"([^"]+)"/)
-  if (imageMatch) {
-    let image = imageMatch[1]
-    // Remove size suffix (^m, ^s, etc.) for full size
+  // Age rating — isAdult flag → 19세이용가.
+  if (og.isAdult === true) {
+    result.data.age_rating = '19세이용가'
+    extracted = true
+  }
+
+  // Thumbnail — when openGraphData.thumbnail is populated, prefer it
+  // (more specific than og:image meta which often falls back to a generic
+  // platform banner on this site).
+  if (typeof og.thumbnail === 'string' && og.thumbnail.trim()) {
+    let image = og.thumbnail.trim()
+    if (image.startsWith('//')) image = `https:${image}`
+    // Remove size suffix (^m, ^s, etc.) for full size when present
     image = image.replace(/\^[a-z]\./, '.')
     result.data.thumbnail = image
     extracted = true
   }
 
-  // Pattern: "countOfFreeEpisodes":5 or total episodes
-  const episodesMatch = html.match(/"(?:countOf(?:Free)?Episodes|totalEpisodes|episodeCount)"\s*:\s*(\d+)/)
-  if (episodesMatch) {
-    result.data.chapters = parseInt(episodesMatch[1], 10)
-    extracted = true
-  }
-
-  // Pattern: "viewCount" or "views"
-  const viewsMatch = html.match(/"(?:viewCount|views|totalViews)"\s*:\s*(\d+)/)
-  if (viewsMatch) {
-    result.data.views = parseInt(viewsMatch[1], 10)
-    extracted = true
-  }
-
-  // Pattern: "likeCount" or "likes"
-  const likesMatch = html.match(/"(?:likeCount|likes|totalLikes)"\s*:\s*(\d+)/)
-  if (likesMatch) {
-    result.data.likes = parseInt(likesMatch[1], 10)
+  // Free episode count is exposed at the top level on /detail/ pages; we
+  // store it as chapters when no better total is available.
+  const freeCount =
+    typeof pageProps.countOfFreeEpisodes === 'number' ? pageProps.countOfFreeEpisodes :
+    typeof og.countOfFreeEpisodes === 'number' ? og.countOfFreeEpisodes : null
+  if (freeCount !== null && freeCount > 0 && !result.data.chapters) {
+    result.data.chapters = freeCount
     extracted = true
   }
 
@@ -367,25 +408,38 @@ function extractFromOgMeta(html: string, result: BomtoonData): boolean {
     }
   }
 
-  // og:description - only if not already set
+  // og:description - only if not already set, and only if it looks
+  // content-specific. Bomtoon's static <meta og:description> is the
+  // generic platform tagline (e.g. "순정, 로맨스, BL 장르가 가득한 여성
+  // 독자를 위한 프리미엄 웹툰") — storing that as synopsis would be wrong.
   if (!result.data.synopsis_kr) {
     const descMatch = html.match(/<meta\s+(?:property|name)="og:description"\s+content="([^"]+)"/i) ||
                       html.match(/<meta\s+content="([^"]+)"\s+(?:property|name)="og:description"/i)
     if (descMatch) {
-      result.data.synopsis_kr = decodeHTMLEntities(descMatch[1])
-      extracted = true
+      const desc = decodeHTMLEntities(descMatch[1])
+      const isGenericTagline = desc.includes('프리미엄 웹툰') || desc.includes('여성 독자')
+      if (desc && !isGenericTagline) {
+        result.data.synopsis_kr = desc
+        extracted = true
+      }
     }
   }
 
-  // og:image - only if not already set
+  // og:image - only if not already set, and only if it's not the generic
+  // platform banner (meta-image.jpg). Bomtoon's per-title cover lives in
+  // openGraphData.thumbnail when populated; the meta tag is shared fallback.
   if (!result.data.thumbnail) {
     const imageMatch = html.match(/<meta\s+(?:property|name)="og:image"\s+content="([^"]+)"/i) ||
                        html.match(/<meta\s+content="([^"]+)"\s+(?:property|name)="og:image"/i)
     if (imageMatch) {
       let image = imageMatch[1]
-      if (image.startsWith('//')) image = `https:${image}`
-      result.data.thumbnail = image
-      extracted = true
+      if (image.includes('meta-image') || image.includes('common/')) {
+        // generic platform banner — skip
+      } else {
+        if (image.startsWith('//')) image = `https:${image}`
+        result.data.thumbnail = image
+        extracted = true
+      }
     }
   }
 

--- a/supabase/functions/title-intelligence/scrapers/naver-series.ts
+++ b/supabase/functions/title-intelligence/scrapers/naver-series.ts
@@ -71,10 +71,16 @@ interface NaverSeriesData {
 
 /**
  * Main scraper function for Naver Series
- * Accepts either a productNo or full URL
+ * Accepts either a productNo or full URL, plus an optional subKind
+ * ('comic' | 'novel') that selects the path on series.naver.com.
+ * Defaults to 'comic' for backward compatibility — webtoons are the
+ * historically supported case.
  */
-export async function scrapeNaverSeries(productNoOrUrl: string): Promise<NaverSeriesData> {
-  console.log(`[NaverSeries] Scraping for: ${productNoOrUrl}`)
+export async function scrapeNaverSeries(
+  productNoOrUrl: string,
+  subKind: 'comic' | 'novel' = 'comic',
+): Promise<NaverSeriesData> {
+  console.log(`[NaverSeries] Scraping for: ${productNoOrUrl} (subKind=${subKind})`)
 
   const result: NaverSeriesData = {
     source: 'naver_series',
@@ -119,12 +125,12 @@ export async function scrapeNaverSeries(productNoOrUrl: string): Promise<NaverSe
       return result
     }
 
-    console.log(`[NaverSeries] Using productNo: ${productNo}`)
+    console.log(`[NaverSeries] Using productNo: ${productNo} (subKind=${subKind})`)
     result.data.productNo = productNo
-    result.data.platform_url = `https://series.naver.com/comic/detail.series?productNo=${productNo}`
+    result.data.platform_url = `https://series.naver.com/${subKind}/detail.series?productNo=${productNo}`
 
     // Fetch HTML and parse data
-    const htmlData = await fetchAndParseHtml(productNo)
+    const htmlData = await fetchAndParseHtml(productNo, subKind)
 
     if (htmlData) {
       result.title_found = true
@@ -182,11 +188,14 @@ function extractProductNo(input: string): string | null {
 /**
  * Fetch HTML page and extract all available data
  */
-async function fetchAndParseHtml(productNo: string): Promise<Partial<NaverSeriesData['data']> | null> {
-  console.log(`[NaverSeries] Fetching HTML for: ${productNo}`)
+async function fetchAndParseHtml(
+  productNo: string,
+  subKind: 'comic' | 'novel' = 'comic',
+): Promise<Partial<NaverSeriesData['data']> | null> {
+  console.log(`[NaverSeries] Fetching HTML for: ${productNo} (${subKind})`)
 
   try {
-    const url = `https://series.naver.com/comic/detail.series?productNo=${productNo}`
+    const url = `https://series.naver.com/${subKind}/detail.series?productNo=${productNo}`
     const response = await fetch(url, { headers: HEADERS })
 
     if (!response.ok) {

--- a/supabase/functions/title-intelligence/scrapers/ridibooks.ts
+++ b/supabase/functions/title-intelligence/scrapers/ridibooks.ts
@@ -144,17 +144,30 @@ export async function scrapeRidibooks(bookIdOrUrl: string): Promise<RidibooksDat
     // Extract data using multiple methods
     let dataExtracted = false
 
-    // Method 1: Direct HTML parsing (most reliable for Ridibooks)
-    dataExtracted = extractFromHtmlContent(html, result)
-    if (dataExtracted) {
+    // Method 1: JSON-LD (schema.org Book) — primary, most reliable.
+    // Ridibooks renders most book detail data client-side; the only
+    // structured server-side payload is a <script type="application/ld+json">
+    // block with name/author/publisher/genre/description/rating/etc.
+    const jsonLdExtracted = extractFromJsonLd(html, result)
+    if (jsonLdExtracted) {
+      result.metadata.scraping_method = 'json_ld'
+      dataExtracted = true
+      console.log(`[Ridibooks] Extracted from JSON-LD`)
+    }
+
+    // Method 2: Direct HTML parsing — supplements (chapters, completed flag,
+    // tags from meta keywords). Patterns specific to Ridibooks DOM/meta.
+    if (extractFromHtmlContent(html, result) && !dataExtracted) {
       result.metadata.scraping_method = 'html_content'
+      dataExtracted = true
       console.log(`[Ridibooks] Extracted from HTML content`)
     }
 
-    // Method 2: Try og:meta tags to supplement
+    // Method 3: og:meta tags as fallback for any remaining gaps
     extractFromOgMeta(html, result)
 
-    // Method 3: Try __NEXT_DATA__ as additional source
+    // Method 4: __NEXT_DATA__ rarely has book data on this platform but
+    // kept as last-resort source for legacy pages.
     extractFromNextData(html, result)
 
     // Check if we got any meaningful data
@@ -601,6 +614,134 @@ function extractFromOgMeta(html: string, result: RidibooksData): boolean {
       if (image.startsWith('//')) image = `https:${image}`
       result.data.thumbnail = image
       extracted = true
+    }
+  }
+
+  return extracted
+}
+
+/**
+ * Extract data from JSON-LD (schema.org Book) blocks.
+ *
+ * Ridibooks emits a clean <script type="application/ld+json"> with the
+ * book's structured data — name, author, publisher, genre, description,
+ * aggregateRating, image, ISBN, etc. This is the only stable
+ * server-side payload that survives the page's heavy client-side rendering,
+ * so it's the primary extraction path.
+ */
+function extractFromJsonLd(html: string, result: RidibooksData): boolean {
+  let extracted = false
+
+  // Find all JSON-LD blocks (matchAll). There can be several (BreadcrumbList,
+  // Book, etc). We pick the first one whose @type is 'Book'.
+  const ldBlockRe = /<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/gi
+  const blocks = Array.from(html.matchAll(ldBlockRe))
+
+  for (const match of blocks) {
+    const body = match[1].trim()
+    if (!body) continue
+
+    let parsed: any
+    try {
+      parsed = JSON.parse(body)
+    } catch (err) {
+      console.log(`[Ridibooks] Skipping JSON-LD block (parse error)`)
+      continue
+    }
+
+    // Some pages use an array of objects; normalize.
+    const candidates: any[] = Array.isArray(parsed) ? parsed : [parsed]
+
+    for (const candidate of candidates) {
+      if (!candidate || typeof candidate !== 'object') continue
+      const type = candidate['@type']
+      if (type !== 'Book' && type !== 'CreativeWork' && type !== 'Article') continue
+
+      // Title
+      if (!result.data.title_ko && typeof candidate.name === 'string') {
+        result.data.title_ko = decodeHTMLEntities(candidate.name)
+        extracted = true
+      }
+
+      // Author (single or array). For multi-author works (typical of
+      // webtoons listing writer + artist), populate `author` with the first
+      // entry and `artist` with the second — JSON-LD doesn't carry role
+      // tags so we use position as a best-effort heuristic. Novels have a
+      // single author and `artist` stays null.
+      const author = candidate.author
+      if (author) {
+        const toName = (v: any) =>
+          typeof v === 'string' ? v : (v && typeof v === 'object' ? v.name : null)
+        const names = (Array.isArray(author) ? author : [author])
+          .map(toName)
+          .filter((n: any): n is string => typeof n === 'string' && n.trim().length > 0)
+        if (!result.data.author && names[0]) {
+          result.data.author = decodeHTMLEntities(names[0].trim())
+          extracted = true
+        }
+        if (!result.data.artist && names[1]) {
+          result.data.artist = decodeHTMLEntities(names[1].trim())
+          extracted = true
+        }
+      }
+
+      // Publisher
+      const publisher = candidate.publisher
+      if (!result.data.publisher && publisher) {
+        const pubName = Array.isArray(publisher)
+          ? (publisher[0]?.name || publisher[0])
+          : (publisher.name || publisher)
+        if (typeof pubName === 'string' && pubName.trim()) {
+          result.data.publisher = decodeHTMLEntities(pubName.trim())
+          extracted = true
+        }
+      }
+
+      // Genre — store as single-element array to match schema
+      if ((!result.data.genre || result.data.genre.length === 0) && candidate.genre) {
+        const g = Array.isArray(candidate.genre) ? candidate.genre[0] : candidate.genre
+        if (typeof g === 'string' && g.trim()) {
+          result.data.genre = [decodeHTMLEntities(g.trim())]
+          extracted = true
+        }
+      }
+
+      // Description / synopsis
+      if (!result.data.synopsis_kr && typeof candidate.description === 'string') {
+        result.data.synopsis_kr = decodeHTMLEntities(candidate.description)
+        extracted = true
+      }
+
+      // Cover image
+      if (!result.data.thumbnail && candidate.image) {
+        const img = Array.isArray(candidate.image) ? candidate.image[0] : candidate.image
+        if (typeof img === 'string' && img.trim()) {
+          result.data.thumbnail = img.trim()
+          extracted = true
+        }
+      }
+
+      // Rating (aggregateRating.ratingValue / ratingCount)
+      const aggr = candidate.aggregateRating
+      if (aggr) {
+        if (!result.data.rating && aggr.ratingValue) {
+          const v = parseFloat(String(aggr.ratingValue))
+          if (!isNaN(v) && v >= 0 && v <= 5) {
+            result.data.rating = v
+            extracted = true
+          }
+        }
+        if (!result.data.rating_count && aggr.ratingCount) {
+          const c = parseInt(String(aggr.ratingCount), 10)
+          if (!isNaN(c) && c >= 0) {
+            result.data.rating_count = c
+            extracted = true
+          }
+        }
+      }
+
+      // First Book candidate wins; stop scanning more blocks.
+      if (type === 'Book') return extracted
     }
   }
 

--- a/supabase/functions/title-intelligence/scrapers/ridibooks.ts
+++ b/supabase/functions/title-intelligence/scrapers/ridibooks.ts
@@ -236,17 +236,24 @@ function extractBookId(input: string): string | null {
 function extractFromHtmlContent(html: string, result: RidibooksData): boolean {
   let extracted = false
 
-  // Extract title from <title> tag first
-  const titleTagMatch = html.match(/<title>([^<]+)<\/title>/i)
-  if (titleTagMatch) {
-    let title = decodeHTMLEntities(titleTagMatch[1])
-    // Clean up - remove suffixes like "- 웹툰 - 리디에만 있는 독점 작품! - 리디"
-    title = title.replace(/\s*-\s*웹툰.*$/i, '').trim()
-    title = title.replace(/\s*-\s*리디.*$/i, '').trim()
-    title = title.replace(/\s*\|\s*리디.*$/i, '').trim()
-    if (title && title.length > 0 && title.length < 100) {
-      result.data.title_ko = title
-      extracted = true
+  // Extract title from <title> tag — used only when JSON-LD didn't already
+  // populate title_ko. The <title> contains a suffix like
+  // "사탄의 아이들 - 판타지 웹소설 - 리디" that's hard to strip cleanly,
+  // so the JSON-LD `name` is preferred when available.
+  if (!result.data.title_ko) {
+    const titleTagMatch = html.match(/<title>([^<]+)<\/title>/i)
+    if (titleTagMatch) {
+      let title = decodeHTMLEntities(titleTagMatch[1])
+      // Strip platform / category suffixes
+      title = title
+        .replace(/\s*-\s*리디.*$/i, '')
+        .replace(/\s*\|\s*리디.*$/i, '')
+        .replace(/\s*-\s*(웹툰|웹소설|만화|판타지 웹소설|로맨스 웹소설|BL 웹소설|로판 웹소설)\b.*$/i, '')
+        .trim()
+      if (title && title.length > 0 && title.length < 100) {
+        result.data.title_ko = title
+        extracted = true
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Audited the title-intelligence scraper against four target URLs and unblocked three platforms:

- **Naver Series novel** (`series.naver.com/novel/...`) — parser regex hardcoded `/comic/`; widened to `(?:comic|novel)` and plumbed a `subKind` field through `ParsedUrl` → edge-function payload → `scrapeNaverSeries(productNo, subKind)` so the scraper builds the right fetch URL.
- **Ridibooks** (`ridibooks.com/books/...`) — rating / author / publisher selectors were stale because the page now renders most details client-side. Added a `schema.org/Book` JSON-LD extractor as the primary path; kept HTML/og:meta as fallbacks. Multi-author works populate `author` + `artist` from positions 0/1.
- **Bomtoon** (`bomtoon.com/detail/{slug}`) — parser regex matched `/series/(\d+)` (wrong on both path and ID type). Updated to `/(?:detail|comic\/ep_list)/(slug)`. Replaced brittle raw-regex JSON extraction with proper `__NEXT_DATA__.pageProps.openGraphData` parsing; rejects the platform's generic og:description / og:image so synopsis/thumbnail no longer get polluted with banners.
- **Kakao Page** — unchanged, already worked.

Also fixed an upstream bug uncovered during end-to-end verification:
- `intelligence_titles.type` CHECK constraint (`webtoon | webnovel | light_novel | manga | mixed`) didn't accept the snake_case `content_format` values from the titles table (`web_novel`, `book`, etc.) — every non-webtoon URL was returning HTTP 500. Added `normalizeContentType()` mapping.
- Ridibooks `extractFromHtmlContent` was clobbering the clean JSON-LD title with the raw `<title>` tag content. Guarded the fallback with `!result.data.title_ko` and broadened the suffix-strip chain.

Edge function has been deployed (`npx supabase functions deploy title-intelligence`).

## Verified end-to-end

All four URLs return HTTP 200 with real scraped data:

| URL | Title | Author | Rating | Chapters | Publisher | Genre |
|---|---|---|---|---|---|---|
| `series.naver.com/novel/?productNo=9051532` | 사탄의 아이들 | 차우렌즈 | 9.2 | 250 | 엠스토리허브 | ["현판"] |
| `page.kakao.com/content/58420770` | 사탄의 아이들 | 차우렌즈 | 9.76 (1837) | 5 free | — | ["웹소설","현판"] |
| `ridibooks.com/books/1962104689` | 사탄의 아이들 | 차우렌즈 | 5.0 (1) | 250 | 엠스토리허브 | ["현대 판타지"] |
| `bomtoon.com/detail/house?porch=tw1386` | 공유하는 집 | 징망츄 (artist 사앙) | — | — | — | ["BL","현대물","캠퍼스물"] |

Bomtoon's nulls (rating/chapters/thumbnail for *this title*) reflect what the platform actually exposes server-side, not extraction failures.

## Test plan
- [x] `parseUrl` recognizes all 4 URLs and sets `subKind` for Naver novel/comic
- [x] Scraper extraction logic verified against live HTML in Node
- [x] Edge function redeployed and called with admin JWT for each URL
- [x] `intelligence_sources.raw_meta.data` confirmed populated with title/author/synopsis/etc.
- [ ] Manual UI test: sign into `/admin/titles`, open the edit modal, paste each URL into the source field, click "Collect Data" — expect a success toast for each

## Out of scope (deferred follow-ups)
- Parser is still duplicated across `packages/tools` and `apps/creator` — consolidation is its own PR.
- Bomtoon's per-title thumbnail/chapter/rating discovery (would require either an API endpoint or a headless browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)