### PR TITLE
Production release: v2 → main

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite --port 8082 --host 0.0.0.0",
+    "dev": "vite --host 0.0.0.0",
     "build": "tsc && vite build",
     "build:dev": "tsc && vite build --mode development",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -54,6 +54,7 @@ import AdminDocs from '@/pages/admin/Docs';
 import TitleDataStructure from '@/pages/admin/TitleDataStructure';
 import EmailTemplates from '@/pages/admin/EmailTemplates';
 import AdminTrending from '@/pages/admin/Trending';
+import AdminMicrodramaSpotlight from '@/pages/admin/MicrodramaSpotlight';
 import WeeklyTitle from '@/pages/admin/WeeklyTitle';
 import TrialConversions from '@/pages/admin/TrialConversions';
 import { AdminProtectedRoute } from '@/components/AdminProtectedRoute';
@@ -272,6 +273,16 @@ function App() {
             element={
               <AdminProtectedRoute>
                 <AdminTrending />
+              </AdminProtectedRoute>
+            }
+          />
+
+          {/* Microdrama Spotlight (score-based, all priorities) */}
+          <Route
+            path="/admin/microdrama-spotlight"
+            element={
+              <AdminProtectedRoute>
+                <AdminMicrodramaSpotlight />
               </AdminProtectedRoute>
             }
           />

--- a/apps/dashboard/src/components/format-spotlight/FormatInsightsTab.tsx
+++ b/apps/dashboard/src/components/format-spotlight/FormatInsightsTab.tsx
@@ -20,7 +20,7 @@ function MicrodramaInsights({ insights }: { insights: MicrodramaSpecificInsights
       {/* Tropes */}
       {insights.trope_alignment && insights.trope_alignment.length > 0 && (
         <div>
-          <p className="text-xs text-gray-500 mb-1.5">Trope Alignment</p>
+          <p className="text-sm font-bold text-gray-900 mb-1.5">Trope Alignment</p>
           <div className="flex flex-wrap gap-1.5">
             {insights.trope_alignment.map((trope, i) => (
               <span
@@ -37,7 +37,7 @@ function MicrodramaInsights({ insights }: { insights: MicrodramaSpecificInsights
       {/* Platforms */}
       {insights.target_platform_fit && insights.target_platform_fit.length > 0 && (
         <div>
-          <p className="text-xs text-gray-500 mb-1.5">Target Platforms</p>
+          <p className="text-sm font-bold text-gray-900 mb-1.5">Target Platforms</p>
           <div className="flex flex-wrap gap-1.5">
             {insights.target_platform_fit.map((platform, i) => (
               <span
@@ -82,7 +82,7 @@ export default function FormatInsightsTab({ analysis, formatType }: FormatInsigh
   if (formatType === 'microdrama' && analysis.format_specific) {
     return (
       <div className="space-y-3">
-        <p className="text-xs font-semibold text-gray-500">
+        <p className="text-sm font-bold text-gray-900">
           {formatName} Insights
         </p>
         <MicrodramaInsights insights={analysis.format_specific} />
@@ -94,7 +94,7 @@ export default function FormatInsightsTab({ analysis, formatType }: FormatInsigh
   if (analysis.recommendations && analysis.recommendations.length > 0) {
     return (
       <div className="space-y-2">
-        <p className="text-xs font-semibold text-gray-500">
+        <p className="text-sm font-bold text-gray-900">
           {formatName} Recommendations
         </p>
         <ul className="space-y-1.5">

--- a/apps/dashboard/src/components/format-spotlight/FormatSpotlightCard.tsx
+++ b/apps/dashboard/src/components/format-spotlight/FormatSpotlightCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Icon } from '@iconify/react';
 import RadarChart from './RadarChart';
@@ -12,6 +11,7 @@ interface TitleData {
   title_name_en: string | null;
   title_name_kr: string | null;
   title_image: string | null;
+  synopsis: string | null;
   genre: string[] | null;
   content_format: string | null;
   tone: string | null;
@@ -26,10 +26,10 @@ interface FormatSpotlightCardProps {
   analysis: FormatAnalysis;
   formatType: FormatType;
   rank?: number;
+  /** Admin editorial note (only present on the curated microdrama path). */
+  note?: string | null;
   onCardClick?: (titleId: string) => void;
 }
-
-type TabType = 'strengths' | 'challenges' | 'insights';
 
 function formatViews(views: number): string {
   if (views >= 1_000_000) return `${(views / 1_000_000).toFixed(1)}M`;
@@ -37,25 +37,34 @@ function formatViews(views: number): string {
   return views.toString();
 }
 
+// Fit-level → color tokens for the top accent + score badge.
+const FIT_STYLES = {
+  excellent: { accent: 'border-t-green-500', badgeBg: 'bg-green-50', badgeText: 'text-green-700', badgeRing: 'ring-green-200' },
+  good: { accent: 'border-t-blue-500', badgeBg: 'bg-blue-50', badgeText: 'text-blue-700', badgeRing: 'ring-blue-200' },
+  default: { accent: 'border-t-gray-400', badgeBg: 'bg-gray-50', badgeText: 'text-gray-700', badgeRing: 'ring-gray-200' },
+} as const;
+
+function getFitStyles(fitLevel: string) {
+  if (fitLevel === 'excellent') return FIT_STYLES.excellent;
+  if (fitLevel === 'good') return FIT_STYLES.good;
+  return FIT_STYLES.default;
+}
+
 export default function FormatSpotlightCard({
   title,
   analysis,
   formatType,
   rank,
+  note,
   onCardClick,
 }: FormatSpotlightCardProps) {
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState<TabType>('strengths');
 
   const score = analysis.overall_score;
   const fitLevel = getFitLevel(score);
   const fitLevelLabel = getFitLevelLabel(score);
-  const radarColor =
-    fitLevel === 'excellent'
-      ? '#22c55e'
-      : fitLevel === 'good'
-        ? '#3b82f6'
-        : '#9ca3af';
+  const styles = getFitStyles(fitLevel);
+  const radarColor = fitLevel === 'excellent' ? '#22c55e' : fitLevel === 'good' ? '#3b82f6' : '#9ca3af';
 
   const handleClick = () => {
     if (onCardClick) {
@@ -65,29 +74,21 @@ export default function FormatSpotlightCard({
     }
   };
 
-  const tabs: { key: TabType; label: string }[] = [
-    { key: 'strengths', label: 'Strengths' },
-    { key: 'challenges', label: 'Challenges' },
-    { key: 'insights', label: 'Format Insights' },
-  ];
+  const strengths = analysis.strengths ?? [];
+  const challenges = analysis.challenges ?? [];
 
   return (
-    <div className={`bg-transparent border border-gray-300 shadow-none rounded-2xl overflow-hidden hover:border-gray-400 transition-colors ${
-      fitLevel === 'excellent'
-        ? 'border-t-[3px] border-t-green-500'
-        : fitLevel === 'good'
-          ? 'border-t-[3px] border-t-blue-500'
-          : 'border-t-[3px] border-t-gray-400'
-    }`}>
-      {/* Top Section */}
+    <div className={`bg-transparent border border-gray-300 shadow-none rounded-2xl overflow-hidden hover:border-gray-400 transition-colors border-t-[3px] ${styles.accent}`}>
+      {/* Header — clickable */}
       <div
         className="p-4 sm:p-5 cursor-pointer hover:bg-gray-50/50 transition-colors"
         onClick={handleClick}
       >
         <div className="flex flex-col sm:flex-row gap-4">
-          {/* Image */}
-          <div className="w-full sm:w-36 md:w-44 shrink-0">
-            <div className="relative aspect-[3/4] w-full rounded-xl overflow-hidden bg-gray-100">
+          <div className="flex gap-4 flex-1 min-w-0">
+          {/* Image + rank — square, height-matched to the 200px radar on desktop */}
+          <div className="w-28 sm:w-[200px] shrink-0">
+            <div className="relative aspect-square w-full rounded-xl overflow-hidden bg-gray-100">
               {title.title_image ? (
                 <img
                   src={title.title_image}
@@ -96,43 +97,40 @@ export default function FormatSpotlightCard({
                 />
               ) : (
                 <div className="w-full h-full flex items-center justify-center">
-                  <Icon icon="solar:book-bold-duotone" className="h-12 w-12 text-gray-300" />
+                  <Icon icon="solar:book-bold-duotone" className="h-10 w-10 text-gray-300" />
                 </div>
               )}
               {rank && (
-                <div className="absolute top-2 left-2 w-8 h-8 rounded-full bg-black ring-2 ring-white/50 text-white text-sm font-bold flex items-center justify-center">
+                <div className="absolute top-2 left-2 w-7 h-7 rounded-full bg-black ring-2 ring-white/50 text-white text-xs font-bold flex items-center justify-center">
                   {rank}
                 </div>
               )}
             </div>
           </div>
 
-          {/* Metadata */}
+          {/* Title + meta */}
           <div className="flex-1 min-w-0">
-            <h3 className="text-lg font-bold text-black truncate">
+            <h3 className="text-xl font-bold text-black leading-tight">
               {title.title_name_en || title.title_name_kr || 'Untitled'}
             </h3>
             {title.title_name_kr && title.title_name_en && (
               <p className="text-sm text-gray-500 truncate">{title.title_name_kr}</p>
             )}
 
-            {/* Genre badges */}
+            {/* Genre / format / tone badges */}
             <div className="flex flex-wrap gap-1.5 mt-2">
               {title.genre?.slice(0, 3).map((g, i) => (
-                <span
-                  key={i}
-                  className="bg-gradient-to-r from-cyan-100 to-cyan-50 text-cyan-800 px-2 py-0.5 rounded-md text-xs font-medium border border-cyan-200"
-                >
+                <span key={i} className="bg-cyan-50 text-cyan-800 px-2 py-0.5 rounded-md text-xs font-medium border border-cyan-200">
                   {g}
                 </span>
               ))}
               {title.content_format && (
-                <span className="bg-gradient-to-r from-purple-100 to-purple-50 text-purple-800 px-2 py-0.5 rounded-md text-xs font-medium border border-purple-200">
+                <span className="bg-purple-50 text-purple-800 px-2 py-0.5 rounded-md text-xs font-medium border border-purple-200">
                   {title.content_format}
                 </span>
               )}
               {title.tone && (
-                <span className="bg-gradient-to-r from-blue-100 to-blue-50 text-blue-800 px-2 py-0.5 rounded-md text-xs font-medium border border-blue-200">
+                <span className="bg-blue-50 text-blue-800 px-2 py-0.5 rounded-md text-xs font-medium border border-blue-200">
                   {title.tone}
                 </span>
               )}
@@ -140,30 +138,20 @@ export default function FormatSpotlightCard({
 
             {/* Authors & stats */}
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-2 text-xs text-gray-500">
-              {title.story_author && (
-                <span>Story: {title.story_author}</span>
-              )}
-              {title.art_author && (
-                <span>Art: {title.art_author}</span>
-              )}
+              {title.story_author && <span>Story: {title.story_author}</span>}
+              {title.art_author && <span>Art: {title.art_author}</span>}
               {title.rating != null && title.rating > 0 && (
                 <span className="flex items-center gap-0.5">
                   <Icon icon="solar:star-bold" className="h-3.5 w-3.5 text-amber-400" />
                   {title.rating.toFixed(1)}
                 </span>
               )}
-              {title.views != null && title.views > 0 && (
-                <span>{formatViews(title.views)} views</span>
-              )}
+              {title.views != null && title.views > 0 && <span>{formatViews(title.views)} views</span>}
             </div>
-
-            {/* Summary */}
-            {analysis.summary && (
-              <p className="mt-2 text-sm text-gray-600 line-clamp-2 border-l-2 border-gray-200 pl-3">{analysis.summary}</p>
-            )}
+          </div>
           </div>
 
-          {/* Radar Chart */}
+          {/* Radar chart — score in center */}
           <div className="shrink-0 flex items-center justify-center sm:justify-end">
             <RadarChart
               dimensions={analysis.dimensions.map((d) => ({
@@ -181,61 +169,60 @@ export default function FormatSpotlightCard({
         </div>
       </div>
 
-      {/* Bottom Section - Tabs */}
-      <div className="border-t border-gray-200">
-        {/* Tab headers */}
-        <div className="flex gap-1 px-2 pt-2">
-          {tabs.map((tab) => (
-            <button
-              key={tab.key}
-              onClick={() => setActiveTab(tab.key)}
-              className={`flex-1 py-3 text-xs font-medium transition-colors rounded-lg ${
-                activeTab === tab.key
-                  ? 'text-black bg-gray-100'
-                  : 'text-gray-500 hover:text-gray-700'
-              }`}
-            >
-              {tab.label}
-            </button>
-          ))}
+      {/* Body */}
+      <div className="px-4 sm:px-5 pb-4 sm:pb-5 space-y-4">
+        {/* Editor's note (admin) */}
+        {note && (
+          <div className="border-l-2 border-hanok-teal bg-hanok-teal/5 rounded-r-lg pl-3 pr-3 py-2.5">
+            <div className="flex items-center gap-1.5 mb-1">
+              <Icon icon="solar:notebook-bold-duotone" className="h-5 w-5 text-hanok-teal" />
+              <span className="text-sm font-bold text-hanok-teal">Editor's note</span>
+            </div>
+            <p className="text-sm text-gray-700">{note}</p>
+          </div>
+        )}
+
+        {/* Synopsis */}
+        {title.synopsis && (
+          <p className="text-sm text-gray-600 leading-relaxed line-clamp-3">{title.synopsis}</p>
+        )}
+
+        {/* Format signals (microdrama gauges + tags, or recommendations) */}
+        <div className="pt-1">
+          <FormatInsightsTab analysis={analysis} formatType={formatType} />
         </div>
 
-        {/* Tab content */}
-        <div className="p-4 min-h-[120px]">
-          {activeTab === 'strengths' && (
-            <ul className="space-y-1.5">
-              {analysis.strengths.length > 0 ? (
-                analysis.strengths.map((s, i) => (
-                  <li key={i} className="flex items-start gap-2 text-sm text-gray-700">
-                    <Icon icon="solar:check-circle-bold" className="h-4 w-4 text-green-500 mt-0.5 shrink-0" />
-                    <span>{s}</span>
-                  </li>
-                ))
-              ) : (
-                <p className="text-sm text-gray-400">No strengths data available.</p>
-              )}
-            </ul>
-          )}
-
-          {activeTab === 'challenges' && (
-            <ul className="space-y-1.5">
-              {analysis.challenges.length > 0 ? (
-                analysis.challenges.map((c, i) => (
-                  <li key={i} className="flex items-start gap-2 text-sm text-gray-700">
-                    <Icon icon="solar:danger-triangle-bold" className="h-4 w-4 text-orange-500 mt-0.5 shrink-0" />
-                    <span>{c}</span>
-                  </li>
-                ))
-              ) : (
-                <p className="text-sm text-gray-400">No challenges data available.</p>
-              )}
-            </ul>
-          )}
-
-          {activeTab === 'insights' && (
-            <FormatInsightsTab analysis={analysis} formatType={formatType} />
-          )}
-        </div>
+        {/* Strengths / Challenges */}
+        {(strengths.length > 0 || challenges.length > 0) && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 pt-1">
+            {strengths.length > 0 && (
+              <div>
+                <p className="text-sm font-bold text-gray-900 mb-1.5">Strengths</p>
+                <ul className="space-y-1">
+                  {strengths.slice(0, 4).map((s, i) => (
+                    <li key={i} className="flex items-start gap-2 text-sm text-gray-700">
+                      <Icon icon="solar:check-circle-bold" className="h-4 w-4 text-green-500 mt-0.5 shrink-0" />
+                      <span>{s}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {challenges.length > 0 && (
+              <div>
+                <p className="text-sm font-bold text-gray-900 mb-1.5">Challenges</p>
+                <ul className="space-y-1">
+                  {challenges.slice(0, 4).map((c, i) => (
+                    <li key={i} className="flex items-start gap-2 text-sm text-gray-700">
+                      <Icon icon="solar:danger-triangle-bold" className="h-4 w-4 text-orange-500 mt-0.5 shrink-0" />
+                      <span>{c}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/layout/AdminLayout.tsx
+++ b/apps/dashboard/src/components/layout/AdminLayout.tsx
@@ -31,6 +31,12 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
       description: 'Manage featured titles'
     },
     {
+      name: 'Microdrama Spotlight',
+      href: '/admin/microdrama-spotlight',
+      icon: 'solar:smartphone-bold-duotone',
+      description: 'Score-based microdrama view'
+    },
+    {
       name: 'Weekly Title',
       href: '/admin/weekly-title',
       icon: 'solar:calendar-bold-duotone',

--- a/apps/dashboard/src/pages/admin/MicrodramaSpotlight.tsx
+++ b/apps/dashboard/src/pages/admin/MicrodramaSpotlight.tsx
@@ -1,0 +1,100 @@
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import AdminLayout from '@/components/layout/AdminLayout';
+import { Icon } from '@iconify/react';
+import { FormatSpotlightCard } from '@/components/format-spotlight';
+import {
+  FORMAT_DISPLAY_NAMES,
+  FORMAT_ICONS,
+  FORMAT_DESCRIPTIONS,
+} from '@/services/formatFitService';
+import { getAdminFormatSpotlightData } from '@/services/formatFitService';
+
+const FORMAT = 'microdrama' as const;
+
+export default function AdminMicrodramaSpotlight() {
+  const navigate = useNavigate();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['admin-format-spotlight', FORMAT],
+    queryFn: () => getAdminFormatSpotlightData(FORMAT),
+  });
+
+  const icon = FORMAT_ICONS[FORMAT];
+  const displayName = FORMAT_DISPLAY_NAMES[FORMAT];
+  const description = FORMAT_DESCRIPTIONS[FORMAT];
+
+  const handleCardClick = (titleId: string) => {
+    navigate(`/admin/titles?highlight=${titleId}`);
+  };
+
+  return (
+    <AdminLayout>
+      <div className="w-full max-w-6xl mx-auto px-4 sm:px-6 py-4 sm:py-6 space-y-6">
+        {/* Header */}
+        <div className="space-y-3">
+          <div className="flex items-center gap-3">
+            <div className="bg-gradient-to-br from-hanok-teal to-hanok-teal/80 p-3 rounded-2xl shadow-lg">
+              <span className="text-2xl">{icon}</span>
+            </div>
+            <div>
+              <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-hanok-teal">
+                {displayName} Spotlight
+              </h1>
+              <p className="text-base sm:text-lg text-gray-600 mt-1">{description}</p>
+            </div>
+          </div>
+          <p className="text-sm sm:text-base text-gray-600">
+            All titles ranked by AI-analyzed {displayName.toLowerCase()} adaptation potential (all priorities shown).
+          </p>
+        </div>
+
+        {/* Loading State */}
+        {isLoading && (
+          <div className="flex flex-col items-center justify-center py-20">
+            <Icon icon="solar:refresh-circle-bold-duotone" className="h-12 w-12 text-hanok-teal animate-spin mb-4" />
+            <p className="text-gray-600 text-sm">Analyzing {displayName.toLowerCase()} potential...</p>
+          </div>
+        )}
+
+        {/* Error State */}
+        {error && (
+          <div className="p-6 bg-red-50 border border-red-200 rounded-2xl">
+            <p className="text-red-800 font-semibold mb-2">Failed to load spotlight data</p>
+            <p className="text-red-600 text-sm">Please try again later or contact support if the problem persists.</p>
+          </div>
+        )}
+
+        {/* Empty State */}
+        {!isLoading && !error && data && data.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-20">
+            <div className="w-16 h-16 rounded-full bg-gray-100 flex items-center justify-center mb-4">
+              <span className="text-2xl">{icon}</span>
+            </div>
+            <h3 className="text-lg font-semibold text-gray-900 mb-2">No Titles Found</h3>
+            <p className="text-gray-600 text-sm text-center max-w-md">
+              No titles currently have a {displayName.toLowerCase()} format fit score above 50. Run Format Fit analysis on titles to populate this view.
+            </p>
+          </div>
+        )}
+
+        {/* Cards */}
+        {!isLoading && !error && data && data.length > 0 && (
+          <div className="space-y-4">
+            {data.map((item, index) => (
+              <FormatSpotlightCard
+                key={item.title.title_id}
+                title={item.title}
+                analysis={item.analysis}
+                formatType={FORMAT}
+                rank={index + 1}
+                note={item.note}
+                onCardClick={(titleId) => handleCardClick(titleId)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </AdminLayout>
+  );
+}

--- a/apps/dashboard/src/pages/buyers/FormatSpotlight.tsx
+++ b/apps/dashboard/src/pages/buyers/FormatSpotlight.tsx
@@ -9,8 +9,9 @@ import {
   FORMAT_DESCRIPTIONS,
   type FormatType,
 } from '@/services/formatFitService';
-import { getFormatSpotlightData } from '@/services/formatFitService';
+import { getFormatSpotlightData, getMicrodramaSpotlightFromFeaturedSection } from '@/services/formatFitService';
 import { trackFormatSpotlightView, trackFormatSpotlightCardClick } from '@/utils/analytics';
+import { useAuth } from '@/hooks/useAuth';
 import { useEffect } from 'react';
 
 const VALID_FORMATS: FormatType[] = ['film', 'tv_series', 'animation', 'microdrama', 'audio_drama'];
@@ -18,10 +19,14 @@ const VALID_FORMATS: FormatType[] = ['film', 'tv_series', 'animation', 'microdra
 export default function FormatSpotlight() {
   const { formatType } = useParams<{ formatType: string }>();
   const navigate = useNavigate();
+  const { user } = useAuth();
 
   const validFormat = VALID_FORMATS.includes(formatType as FormatType)
     ? (formatType as FormatType)
     : null;
+
+  const isMicrodrama = validFormat === 'microdrama';
+  const userEmail = user?.email;
 
   useEffect(() => {
     if (validFormat) {
@@ -30,9 +35,18 @@ export default function FormatSpotlight() {
   }, [validFormat]);
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ['format-spotlight', validFormat],
-    queryFn: () => getFormatSpotlightData(validFormat!),
-    enabled: !!validFormat,
+    queryKey: isMicrodrama
+      ? ['microdrama-spotlight-featured', userEmail]
+      : ['format-spotlight', validFormat],
+    queryFn: isMicrodrama
+      ? () => getMicrodramaSpotlightFromFeaturedSection(userEmail!)
+      : () => getFormatSpotlightData(validFormat!),
+    // Microdrama needs the user's email to auto-generate missing analysis.
+    enabled: isMicrodrama ? !!userEmail : !!validFormat,
+    // Always refetch on mount so admin reorders/curation changes show immediately
+    // (overrides the app-wide 5-min staleTime).
+    staleTime: 0,
+    refetchOnMount: 'always',
   });
 
   if (!validFormat) {
@@ -122,6 +136,7 @@ export default function FormatSpotlight() {
                 analysis={item.analysis}
                 formatType={validFormat}
                 rank={index + 1}
+                note={item.note}
                 onCardClick={(titleId) => handleCardClick(titleId, index + 1)}
               />
             ))}

--- a/apps/dashboard/src/services/formatFitService.ts
+++ b/apps/dashboard/src/services/formatFitService.ts
@@ -135,9 +135,11 @@ export async function deleteFormatFit(titleId: string) {
 
 interface SpotlightTitleData {
   title_id: string;
+  slug?: string | null;
   title_name_en: string | null;
   title_name_kr: string | null;
   title_image: string | null;
+  synopsis: string | null;
   genre: string[] | null;
   content_format: string | null;
   tone: string | null;
@@ -150,6 +152,8 @@ interface SpotlightTitleData {
 interface SpotlightItem {
   title: SpotlightTitleData;
   analysis: import('@kstorybridge/tools').FormatAnalysis;
+  // Admin editorial note (only set on the curated microdrama path).
+  note?: string | null;
 }
 
 /**
@@ -192,7 +196,7 @@ export async function getFormatSpotlightData(
   const titleIds = filtered.map((r) => r.title_id);
   const { data: titles, error: titlesError } = await supabase
     .from('titles')
-    .select('title_id, slug, title_name_en, title_name_kr, title_image, genre, content_format, tone, story_author, art_author, rating, views')
+    .select('title_id, slug, title_name_en, title_name_kr, title_image, synopsis, genre, content_format, tone, story_author, art_author, rating, views')
     .in('title_id', titleIds)
     .in('priority', ['1', '2']);
 
@@ -213,6 +217,179 @@ export async function getFormatSpotlightData(
         title: titleData as SpotlightTitleData,
         analysis,
       };
+    })
+    .filter((item): item is SpotlightItem => item !== null);
+}
+
+/**
+ * Get format spotlight data for admin: same as getFormatSpotlightData but
+ * includes all priority levels (no buyer-side priority filter).
+ */
+export async function getAdminFormatSpotlightData(
+  formatType: import('@kstorybridge/tools').FormatType,
+  minScore: number = 50
+): Promise<SpotlightItem[]> {
+  const scoreKey = `${formatType}_score`;
+  const analysisKey = `${formatType}_analysis`;
+
+  const { data: fitData, error: fitError } = await supabase
+    .from('title_format_fit')
+    .select('title_id, film_score, tv_series_score, animation_score, microdrama_score, audio_drama_score, film_analysis, tv_series_analysis, animation_analysis, microdrama_analysis, audio_drama_analysis');
+
+  if (fitError) {
+    console.error('[AdminFormatSpotlight] Fetch error:', fitError);
+    throw new Error('Failed to fetch format spotlight data');
+  }
+
+  const filtered = (fitData || [])
+    .filter((row) => {
+      const score = (row as Record<string, unknown>)[scoreKey] as number | null;
+      return score !== null && score >= minScore;
+    })
+    .sort((a, b) => {
+      const scoreA = ((a as Record<string, unknown>)[scoreKey] as number) || 0;
+      const scoreB = ((b as Record<string, unknown>)[scoreKey] as number) || 0;
+      return scoreB - scoreA;
+    });
+
+  if (filtered.length === 0) return [];
+
+  const titleIds = filtered.map((r) => r.title_id);
+  const { data: titles, error: titlesError } = await supabase
+    .from('titles')
+    .select('title_id, slug, title_name_en, title_name_kr, title_image, synopsis, genre, content_format, tone, story_author, art_author, rating, views')
+    .in('title_id', titleIds);
+
+  if (titlesError) {
+    console.error('[AdminFormatSpotlight] Titles fetch error:', titlesError);
+    throw new Error('Failed to fetch title details');
+  }
+
+  const titlesMap = new Map((titles || []).map((t) => [t.title_id, t]));
+
+  return filtered
+    .map((row) => {
+      const titleData = titlesMap.get(row.title_id);
+      if (!titleData) return null;
+      const analysis = (row as Record<string, unknown>)[analysisKey] as import('@kstorybridge/tools').FormatAnalysis;
+      if (!analysis) return null;
+      return {
+        title: titleData as SpotlightTitleData,
+        analysis,
+      };
+    })
+    .filter((item): item is SpotlightItem => item !== null);
+}
+
+/**
+ * Get microdrama spotlight titles curated by admin via the Trending featured section.
+ * Finds the first active featured_section whose name contains "microdrama" (case-insensitive),
+ * then returns its titles in admin display_order, joined with format-fit analysis.
+ *
+ * Curated titles that lack microdrama analysis have it auto-generated on demand via
+ * analyzeFormatFit (the edge function persists the result, so this is a one-time cost per
+ * title). Generation runs in parallel; a title whose generation fails is skipped so the
+ * rest still render.
+ *
+ * @param userEmail - the viewing user's email, required by the format-fit-engine edge function.
+ */
+export async function getMicrodramaSpotlightFromFeaturedSection(userEmail: string): Promise<SpotlightItem[]> {
+  // Find the active microdrama section
+  const { data: sections, error: sectionsError } = await supabase
+    .from('featured_sections')
+    .select('id, name')
+    .eq('is_active', true)
+    .ilike('name', '%microdrama%')
+    .limit(1);
+
+  if (sectionsError) {
+    console.error('[MicrodramaSpotlight] Sections fetch error:', sectionsError);
+    throw new Error('Failed to fetch microdrama section');
+  }
+
+  if (!sections || sections.length === 0) return [];
+
+  const sectionId = sections[0].id;
+
+  // Fetch featured entries for this section with title details.
+  // Admin curation overrides the buyer-surface priority gate, so titles of any
+  // priority (including Low) appear here when explicitly added to the section.
+  const { data: featured, error: featuredError } = await supabase
+    .from('featured')
+    .select(`
+      title_id,
+      display_order,
+      note,
+      titles (
+        title_id, slug, title_name_en, title_name_kr, title_image, synopsis,
+        genre, content_format, tone, story_author, art_author, rating, views, priority
+      )
+    `)
+    .eq('section_id', sectionId)
+    .order('display_order', { ascending: true });
+
+  if (featuredError) {
+    console.error('[MicrodramaSpotlight] Featured fetch error:', featuredError);
+    throw new Error('Failed to fetch featured titles');
+  }
+
+  // Normalize the join. Keep every curated title regardless of priority;
+  // drop only rows whose underlying title is missing (e.g. deleted).
+  const validFeatured = (featured || [])
+    .map((f) => ({
+      ...f,
+      titles: Array.isArray(f.titles) ? f.titles[0] : f.titles,
+    }))
+    .filter((f) => f.titles != null);
+
+  if (validFeatured.length === 0) return [];
+
+  // Fetch format-fit analysis for these titles
+  const titleIds = validFeatured.map((f) => f.title_id);
+  const { data: fitData, error: fitError } = await supabase
+    .from('title_format_fit')
+    .select('title_id, microdrama_score, microdrama_analysis')
+    .in('title_id', titleIds);
+
+  if (fitError) {
+    console.error('[MicrodramaSpotlight] Format fit fetch error:', fitError);
+    throw new Error('Failed to fetch format fit data');
+  }
+
+  // Build a map of existing analyses, keyed by title_id.
+  const analysisMap = new Map<string, import('@kstorybridge/tools').FormatAnalysis>(
+    (fitData || [])
+      .filter((r) => r.microdrama_analysis)
+      .map((r) => [r.title_id, r.microdrama_analysis as import('@kstorybridge/tools').FormatAnalysis])
+  );
+
+  // Auto-generate microdrama analysis for curated titles that don't have it yet.
+  // The edge function persists the result, so each title is generated at most once.
+  const missingIds = titleIds.filter((id) => !analysisMap.has(id));
+  if (missingIds.length > 0) {
+    const results = await Promise.allSettled(
+      missingIds.map((id) => analyzeFormatFit(id, userEmail, 'auto'))
+    );
+    results.forEach((result, i) => {
+      const titleId = missingIds[i];
+      if (result.status === 'fulfilled' && result.value?.microdrama_analysis) {
+        analysisMap.set(titleId, result.value.microdrama_analysis);
+      } else if (result.status === 'rejected') {
+        console.error(`[MicrodramaSpotlight] Auto-generate failed for ${titleId}:`, result.reason);
+      }
+    });
+  }
+
+  // Assemble in admin display_order, skipping titles whose analysis is still unavailable.
+  return validFeatured
+    .map((f) => {
+      const analysis = analysisMap.get(f.title_id);
+      if (!analysis) return null;
+      return {
+        title: f.titles as SpotlightTitleData,
+        analysis,
+        note: (f as { note?: string | null }).note ?? null,
+      } as SpotlightItem;
     })
     .filter((item): item is SpotlightItem => item !== null);
 }


### PR DESCRIPTION
Production release promoting the current `v2` staging branch to `main`.

## Latest in this batch
- **Microdrama Spotlight repurposed** (`4bb37cd1`): the buyer Microdrama Spotlight now sources titles from the admin's curated "Microdrama-Ready" Trending section (in admin drag order), auto-generates missing Format Fit analysis on demand, lets curated titles bypass the Low-priority hide, and refetches on mount so admin reorders show immediately. Adds an admin copy at `/admin/microdrama-spotlight` (score-ranked, all priorities) and a redesigned spotlight card (streamlined layout, square cover matched to the radar, synopsis + admin editor's note, prominent section labels).

## Scope
This is the standard staging→production batch and includes all `v2` commits ahead of `main` (~170), covering recent dashboard, website, marketing, and title-intelligence work.

## Verification
- `npm run build:dashboard` passes (0 errors).
- Microdrama Spotlight verified live on localhost: all 6 curated titles render in admin order with the redesigned card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)