### PR TITLE
feat(dashboard): unlisted Low-priority titles + LOW PRIORITY admin badge

### DIFF
--- a/apps/dashboard/src/components/admin/LowPriorityBadge.tsx
+++ b/apps/dashboard/src/components/admin/LowPriorityBadge.tsx
@@ -1,0 +1,26 @@
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+interface LowPriorityBadgeProps {
+  /** Title priority: '1'=High, '2'=Medium, '3'=Low. Null/unset is treated as Low. */
+  priority?: string | null;
+  className?: string;
+}
+
+/**
+ * Admin-only warning sticker for Low-priority (or unset) titles.
+ *
+ * Low/null titles are hidden from buyer lists, search, AI tools, and the pitch
+ * PDF, so admins need a clear visual cue when one shows up in an admin surface.
+ * Renders nothing for High/Medium titles. Mirrors the HIGH PRIORITY badge in
+ * TitleHero.tsx.
+ */
+export function LowPriorityBadge({ priority, className }: LowPriorityBadgeProps) {
+  if (priority !== '3' && priority) return null;
+
+  return (
+    <Badge className={cn('bg-red-500 text-white text-xs', className)}>
+      LOW PRIORITY
+    </Badge>
+  );
+}

--- a/apps/dashboard/src/components/admin/TitleEditModal.tsx
+++ b/apps/dashboard/src/components/admin/TitleEditModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { auditService, type TitleAudit } from '@/services/auditService';
 import { Button } from '@/components/ui/button';
+import { LowPriorityBadge } from '@/components/admin/LowPriorityBadge';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -264,8 +265,7 @@ export function TitleEditModal({
     setFormatFitData(null);
     setAudit(null);
     try {
-      // Admin context — every title is editable regardless of priority.
-      const data = await titlesService.getTitleById(id, { includeAllPriorities: true });
+      const data = await titlesService.getTitleById(id);
       if (data) {
         setTitle(data);
         setFormData(data);
@@ -500,7 +500,7 @@ export function TitleEditModal({
       );
 
       // Refresh form data (admin context)
-      const updatedTitle = await titlesService.getTitleById(titleId, { includeAllPriorities: true });
+      const updatedTitle = await titlesService.getTitleById(titleId);
       if (updatedTitle) {
         setTitle(updatedTitle);
         setFormData(updatedTitle);
@@ -600,7 +600,10 @@ export function TitleEditModal({
       <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="text-xl flex items-center justify-between">
-            <span>Edit Title: {title?.title_name_en || title?.title_name_kr || 'Loading...'}</span>
+            <span className="flex items-center gap-2">
+              Edit Title: {title?.title_name_en || title?.title_name_kr || 'Loading...'}
+              <LowPriorityBadge priority={title?.priority} />
+            </span>
             <div className="flex items-center gap-2">
               <Button
                 type="button"

--- a/apps/dashboard/src/components/format-spotlight/FormatSpotlightCard.tsx
+++ b/apps/dashboard/src/components/format-spotlight/FormatSpotlightCard.tsx
@@ -4,6 +4,7 @@ import RadarChart from './RadarChart';
 import FormatInsightsTab from './FormatInsightsTab';
 import type { FormatAnalysis, FormatType } from '@/services/formatFitService';
 import { getFitLevel, getFitLevelLabel } from '@/services/formatFitService';
+import { LowPriorityBadge } from '@/components/admin/LowPriorityBadge';
 
 interface TitleData {
   title_id: string;
@@ -19,6 +20,7 @@ interface TitleData {
   art_author: string | null;
   rating: number | null;
   views: number | null;
+  priority?: string | null;
 }
 
 interface FormatSpotlightCardProps {
@@ -28,6 +30,8 @@ interface FormatSpotlightCardProps {
   rank?: number;
   /** Admin editorial note (only present on the curated microdrama path). */
   note?: string | null;
+  /** Show the admin-only LOW PRIORITY sticker. Buyer surfaces leave this off. */
+  showLowPriorityBadge?: boolean;
   onCardClick?: (titleId: string) => void;
 }
 
@@ -56,6 +60,7 @@ export default function FormatSpotlightCard({
   formatType,
   rank,
   note,
+  showLowPriorityBadge = false,
   onCardClick,
 }: FormatSpotlightCardProps) {
   const navigate = useNavigate();
@@ -110,9 +115,12 @@ export default function FormatSpotlightCard({
 
           {/* Title + meta */}
           <div className="flex-1 min-w-0">
-            <h3 className="text-xl font-bold text-black leading-tight">
-              {title.title_name_en || title.title_name_kr || 'Untitled'}
-            </h3>
+            <div className="flex items-center gap-2">
+              <h3 className="text-xl font-bold text-black leading-tight">
+                {title.title_name_en || title.title_name_kr || 'Untitled'}
+              </h3>
+              {showLowPriorityBadge && <LowPriorityBadge priority={title.priority} />}
+            </div>
             {title.title_name_kr && title.title_name_en && (
               <p className="text-sm text-gray-500 truncate">{title.title_name_kr}</p>
             )}

--- a/apps/dashboard/src/pages/admin/AdminTitleEdit.tsx
+++ b/apps/dashboard/src/pages/admin/AdminTitleEdit.tsx
@@ -22,6 +22,7 @@ import AdminLayout from '@/components/layout/AdminLayout';
 import { useToast } from '@/hooks/use-toast';
 import { titlesService, Title } from '@/services/titlesService';
 import { Icon } from '@iconify/react';
+import { LowPriorityBadge } from '@/components/admin/LowPriorityBadge';
 
 // Genre options
 const GENRE_OPTIONS = [
@@ -66,7 +67,7 @@ export default function AdminTitleEdit() {
   const fetchTitle = async (id: string) => {
     setLoading(true);
     try {
-      const data = await titlesService.getTitleById(id, { includeAllPriorities: true });
+      const data = await titlesService.getTitleById(id);
       if (data) {
         setTitle(data);
         setFormData(data);
@@ -187,7 +188,10 @@ export default function AdminTitleEdit() {
               <Icon icon="solar:arrow-left-bold-duotone" className="h-4 w-4" />
             </Button>
             <div>
-              <h1 className="text-2xl font-bold text-black">Edit Title</h1>
+              <div className="flex items-center gap-2">
+                <h1 className="text-2xl font-bold text-black">Edit Title</h1>
+                <LowPriorityBadge priority={title.priority} />
+              </div>
               <p className="text-sm text-gray-600 mt-1">
                 {title.title_name_en || title.title_name_kr || 'Untitled'}
               </p>

--- a/apps/dashboard/src/pages/admin/AdminTitles.tsx
+++ b/apps/dashboard/src/pages/admin/AdminTitles.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input';
 import AdminLayout from '@/components/layout/AdminLayout';
 import { TitleEditModal } from '@/components/admin/TitleEditModal';
 import { AuditRunModal } from '@/components/admin/AuditRunModal';
+import { LowPriorityBadge } from '@/components/admin/LowPriorityBadge';
 import { useToast } from '@/hooks/use-toast';
 import { titlesService, Title } from '@/services/titlesService';
 import { Icon } from '@iconify/react';
@@ -589,8 +590,11 @@ export default function AdminTitles() {
                               </div>
                             )}
                             <div>
-                              <div className="text-sm font-medium text-black hover:text-hanok-teal">
-                                {title.title_name_en || title.title_name_kr}
+                              <div className="flex items-center gap-2">
+                                <div className="text-sm font-medium text-black hover:text-hanok-teal">
+                                  {title.title_name_en || title.title_name_kr}
+                                </div>
+                                <LowPriorityBadge priority={title.priority} />
                               </div>
                               {title.title_name_kr && title.title_name_en && (
                                 <div className="text-xs text-gray-500">

--- a/apps/dashboard/src/pages/admin/MicrodramaSpotlight.tsx
+++ b/apps/dashboard/src/pages/admin/MicrodramaSpotlight.tsx
@@ -89,6 +89,7 @@ export default function AdminMicrodramaSpotlight() {
                 formatType={FORMAT}
                 rank={index + 1}
                 note={item.note}
+                showLowPriorityBadge
                 onCardClick={(titleId) => handleCardClick(titleId)}
               />
             ))}

--- a/apps/dashboard/src/pages/admin/TitleEdit.tsx
+++ b/apps/dashboard/src/pages/admin/TitleEdit.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useToast } from '@/hooks/use-toast';
 import { titlesService, Title } from '@/services/titlesService';
 import { Icon } from '@iconify/react';
+import { LowPriorityBadge } from '@/components/admin/LowPriorityBadge';
 
 export default function TitleEdit() {
   const { toast } = useToast();
@@ -29,7 +30,7 @@ export default function TitleEdit() {
   const loadTitle = async (id: string) => {
     try {
       setLoading(true);
-      const data = await titlesService.getTitleById(id, { includeAllPriorities: true });
+      const data = await titlesService.getTitleById(id);
       setTitle(data);
       setFormData(data || {});
     } catch (error: any) {
@@ -110,7 +111,10 @@ export default function TitleEdit() {
               <Icon icon="solar:arrow-left-bold-duotone" className="h-4 w-4 mr-2" />
               Back to Titles
             </Button>
-            <h1 className="text-3xl font-bold text-black">Edit Title</h1>
+            <div className="flex items-center gap-2">
+              <h1 className="text-3xl font-bold text-black">Edit Title</h1>
+              <LowPriorityBadge priority={title.priority} />
+            </div>
             <p className="text-gray-600 mt-1">
               {title.title_name_en || title.title_name_kr}
             </p>

--- a/apps/dashboard/src/pages/admin/Trending.tsx
+++ b/apps/dashboard/src/pages/admin/Trending.tsx
@@ -27,6 +27,7 @@ import { TitleEditModal } from '@/components/admin/TitleEditModal';
 import { useToast } from '@/hooks/use-toast';
 import { featuredService, type FeaturedWithTitle } from '@/services/featuredService';
 import { titlesService, type Title } from '@/services/titlesService';
+import { LowPriorityBadge } from '@/components/admin/LowPriorityBadge';
 import type { FeaturedSection } from '@/types/featured';
 import { Icon } from '@iconify/react';
 
@@ -475,7 +476,10 @@ export default function AdminTrending() {
               </div>
             )}
             <div>
-              <div className="text-sm font-medium text-gray-900 hover:text-hanok-teal">{titleName}</div>
+              <div className="flex items-center gap-2">
+                <div className="text-sm font-medium text-gray-900 hover:text-hanok-teal">{titleName}</div>
+                <LowPriorityBadge priority={item.titles?.priority} />
+              </div>
               {item.titles?.title_name_en && titleNameKr && (
                 <div className="text-xs text-gray-500">{titleNameKr}</div>
               )}
@@ -724,8 +728,11 @@ export default function AdminTrending() {
                 {selectedTitle ? (
                   <div className="flex items-center gap-2 p-2 bg-gray-50 border border-gray-200 rounded-lg">
                     <div className="flex-1 min-w-0">
-                      <div className="text-sm font-medium text-black truncate">
-                        {selectedTitle.title_name_en || selectedTitle.title_name_kr}
+                      <div className="flex items-center gap-2">
+                        <div className="text-sm font-medium text-black truncate">
+                          {selectedTitle.title_name_en || selectedTitle.title_name_kr}
+                        </div>
+                        <LowPriorityBadge priority={selectedTitle.priority} />
                       </div>
                       {selectedTitle.title_name_en && selectedTitle.title_name_kr && (
                         <div className="text-xs text-gray-500 truncate">{selectedTitle.title_name_kr}</div>
@@ -780,8 +787,11 @@ export default function AdminTrending() {
                                 }`}
                               >
                                 <div className="flex items-center justify-between">
-                                  <div className="text-sm font-medium text-gray-900">
-                                    {title.title_name_en || title.title_name_kr}
+                                  <div className="flex items-center gap-2">
+                                    <div className="text-sm font-medium text-gray-900">
+                                      {title.title_name_en || title.title_name_kr}
+                                    </div>
+                                    <LowPriorityBadge priority={title.priority} />
                                   </div>
                                   {isAlreadyFeatured && (
                                     <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600">

--- a/apps/dashboard/src/pages/admin/WeeklyTitle.tsx
+++ b/apps/dashboard/src/pages/admin/WeeklyTitle.tsx
@@ -15,6 +15,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/useAuth';
 import { Icon } from '@iconify/react';
 import { titlesService, type Title } from '@/services/titlesService';
+import { LowPriorityBadge } from '@/components/admin/LowPriorityBadge';
 import {
   weeklyTitleService,
   type WeeklyTitleWithTitle,
@@ -289,15 +290,18 @@ export default function WeeklyTitle() {
                   />
                 )}
                 <div className="flex-1 min-w-0">
-                  <Link
-                    to={`/buyers/titles/${selectedTitle.slug || selectedTitle.title_id}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="font-semibold text-black truncate hover:text-hanok-teal hover:underline flex items-center gap-1"
-                  >
-                    {selectedTitle.title_name_en || selectedTitle.title_name_kr}
-                    <Icon icon="solar:arrow-right-up-linear" className="h-3 w-3 text-gray-400" />
-                  </Link>
+                  <div className="flex items-center gap-2">
+                    <Link
+                      to={`/buyers/titles/${selectedTitle.slug || selectedTitle.title_id}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-semibold text-black truncate hover:text-hanok-teal hover:underline flex items-center gap-1"
+                    >
+                      {selectedTitle.title_name_en || selectedTitle.title_name_kr}
+                      <Icon icon="solar:arrow-right-up-linear" className="h-3 w-3 text-gray-400" />
+                    </Link>
+                    <LowPriorityBadge priority={selectedTitle.priority} />
+                  </div>
                   {selectedTitle.title_name_en && selectedTitle.title_name_kr && (
                     <div className="text-sm text-gray-600 truncate">
                       {selectedTitle.title_name_kr}
@@ -400,8 +404,11 @@ export default function WeeklyTitle() {
                         onClick={() => handleSelectTitle(title)}
                         className="w-full px-4 py-2 text-left hover:bg-gray-50 border-b border-gray-100 last:border-b-0"
                       >
-                        <div className="font-medium text-gray-900">
-                          {title.title_name_en || title.title_name_kr}
+                        <div className="flex items-center gap-2">
+                          <div className="font-medium text-gray-900">
+                            {title.title_name_en || title.title_name_kr}
+                          </div>
+                          <LowPriorityBadge priority={title.priority} />
                         </div>
                         {title.title_name_en && title.title_name_kr && (
                           <div className="text-xs text-gray-500">{title.title_name_kr}</div>

--- a/apps/dashboard/src/services/featuredService.ts
+++ b/apps/dashboard/src/services/featuredService.ts
@@ -40,7 +40,8 @@ export const featuredService = {
           content_format,
           rating,
           story_author,
-          art_author
+          art_author,
+          priority
         )
       `)
       .order('created_at', { ascending: false });

--- a/apps/dashboard/src/services/formatFitService.ts
+++ b/apps/dashboard/src/services/formatFitService.ts
@@ -147,6 +147,7 @@ interface SpotlightTitleData {
   art_author: string | null;
   rating: number | null;
   views: number | null;
+  priority?: string | null;
 }
 
 interface SpotlightItem {
@@ -257,7 +258,7 @@ export async function getAdminFormatSpotlightData(
   const titleIds = filtered.map((r) => r.title_id);
   const { data: titles, error: titlesError } = await supabase
     .from('titles')
-    .select('title_id, slug, title_name_en, title_name_kr, title_image, synopsis, genre, content_format, tone, story_author, art_author, rating, views')
+    .select('title_id, slug, title_name_en, title_name_kr, title_image, synopsis, genre, content_format, tone, story_author, art_author, rating, views, priority')
     .in('title_id', titleIds);
 
   if (titlesError) {

--- a/apps/dashboard/src/services/titlesService.test.ts
+++ b/apps/dashboard/src/services/titlesService.test.ts
@@ -655,32 +655,22 @@ describe('TitlesService', () => {
       expect(priorityCalls).toHaveLength(0);
     });
 
-    it('getTitleById: returns null when title has priority=3 (buyer call)', async () => {
+    it('getTitleById: returns Low-priority (priority=3) title — detail page is unlisted, not hidden', async () => {
       const lowTitle = { ...mockTitles[0], priority: '3', title_content_analysis: null };
       const mockBuilder = createMockQueryBuilder({ data: lowTitle, error: null });
       vi.mocked(supabase.from).mockReturnValue(mockBuilder as any);
 
       const result = await titlesService.getTitleById('title-1');
 
-      expect(result).toBeNull();
+      expect(result?.title_id).toBe('title-1');
     });
 
-    it('getTitleById: returns null when title has priority=null (buyer call)', async () => {
+    it('getTitleById: returns title when priority=null', async () => {
       const nullTitle = { ...mockTitles[0], priority: null, title_content_analysis: null };
       const mockBuilder = createMockQueryBuilder({ data: nullTitle, error: null });
       vi.mocked(supabase.from).mockReturnValue(mockBuilder as any);
 
       const result = await titlesService.getTitleById('title-1');
-
-      expect(result).toBeNull();
-    });
-
-    it('getTitleById: returns Low-priority title when includeAllPriorities=true (admin)', async () => {
-      const lowTitle = { ...mockTitles[0], priority: '3', title_content_analysis: null };
-      const mockBuilder = createMockQueryBuilder({ data: lowTitle, error: null });
-      vi.mocked(supabase.from).mockReturnValue(mockBuilder as any);
-
-      const result = await titlesService.getTitleById('title-1', { includeAllPriorities: true });
 
       expect(result?.title_id).toBe('title-1');
     });

--- a/apps/dashboard/src/services/titlesService.ts
+++ b/apps/dashboard/src/services/titlesService.ts
@@ -451,11 +451,12 @@ class TitlesService {
    * Fetch a single title by ID with pitch analysis, platforms, and documents.
    * Uses multiple queries for better reliability.
    *
-   * Buyer-facing pages (TitleDetail) leave options undefined and Low-priority
-   * titles return null — the buyer sees a 404 even via direct URL. Admin
-   * detail pages pass { includeAllPriorities: true } so they can edit any row.
+   * The detail page renders a title regardless of priority — Low/null titles
+   * are "unlisted" (hidden from lists, search, AI tools, and the pitch PDF) but
+   * reachable by direct link. List/search surfaces apply their own priority
+   * filter; this single-row fetch does not.
    */
-  async getTitleById(titleId: string, options?: { includeAllPriorities?: boolean }): Promise<Title | null> {
+  async getTitleById(titleId: string): Promise<Title | null> {
     try {
       // Query 1: Get title data with content analysis
       const { data, error } = await supabase
@@ -477,12 +478,6 @@ class TitlesService {
 
       if (!data) {
         console.log('ℹ️ Title not found:', titleId);
-        return null;
-      }
-
-      // Block Low-priority titles from buyer pages: treat as 404.
-      if (!options?.includeAllPriorities && (data.priority === '3' || data.priority == null)) {
-        console.log('ℹ️ Title not visible to buyers (Low priority):', titleId);
         return null;
       }
 
@@ -568,14 +563,14 @@ class TitlesService {
 
   /**
    * Fetch a single title by slug with pitch analysis, platforms, and documents.
-   * Same priority gate as getTitleById — pass includeAllPriorities for admin views.
+   * Renders regardless of priority, same as getTitleById.
    */
-  async getTitleBySlug(slug: string, options?: { includeAllPriorities?: boolean }): Promise<Title | null> {
+  async getTitleBySlug(slug: string): Promise<Title | null> {
     try {
       // Backward compatibility: if slug is actually a UUID, fetch by ID directly
       const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
       if (uuidPattern.test(slug)) {
-        return this.getTitleById(slug, options);
+        return this.getTitleById(slug);
       }
 
       const { data, error } = await supabase
@@ -594,7 +589,7 @@ class TitlesService {
         return null;
       }
 
-      return this.getTitleById(data.title_id, options);
+      return this.getTitleById(data.title_id);
     } catch (error: unknown) {
       console.error('❌ Title by slug service error:', error);
       throw error;

--- a/apps/dashboard/src/services/weeklyTitleService.ts
+++ b/apps/dashboard/src/services/weeklyTitleService.ts
@@ -150,7 +150,8 @@ export async function getWeeklyTitleByWeek(
         story_author,
         art_author,
         title_url,
-        title_url_en
+        title_url_en,
+        priority
       )
     `)
     .eq('week_of', weekOf)

--- a/docs/active/DATABASE_SCHEMA.md
+++ b/docs/active/DATABASE_SCHEMA.md
@@ -352,7 +352,10 @@ CREATE TABLE public.titles (
 - `embedding_updated_at`: Last embedding update
 
 **System**:
-- `priority`: Content priority level (enum: '1' = high, '2' = medium, '3' = low)
+- `priority`: Content priority level (enum: '1' = high, '2' = medium, '3' = low; null treated as low)
+  - **Buyer visibility ("unlisted" model)**: Low/null titles are excluded from buyer lists, search, AI chat, Comps Navigator, Mandate Matcher, Format Fit, and the pitch-deck PDF (`SecurePDFViewer`). They are **not** removed.
+  - **Detail page**: The title detail page renders regardless of priority — a Low/null title is reachable by direct link (`/buyers/titles/:slug`, public `/titles/:slug`, and trial pages) even though it never appears in any list. `titlesService.getTitleById`/`getTitleBySlug` no longer filter by priority.
+  - **Admin UI**: All admin title surfaces (AdminTitles table, TitleEditModal, AdminTitleEdit/TitleEdit, Trending, WeeklyTitle, Microdrama/Format Spotlight) show a red **LOW PRIORITY** sticker via `LowPriorityBadge` (`@/components/admin/LowPriorityBadge`) on Low/null titles. High titles get a teal HIGH PRIORITY badge on the detail hero.
 - `verified`: Boolean flag indicating official/verified content (default: false)
   - **Purpose**: Marks titles as officially verified/authenticated content
   - **Default**: false for all new titles


### PR DESCRIPTION
## Summary

Promotes the current `v2` staging changes to production. Headline change: Low-priority titles become **unlisted** rather than fully hidden, and admins get a clear **LOW PRIORITY** badge.

### Primary change (this PR's main commit)
- **Detail page renders regardless of priority.** Removed the priority gate (and dead `includeAllPriorities` option) from `titlesService.getTitleById`/`getTitleBySlug`. A Low/null title is now reachable by direct link on buyer (`/buyers/titles/:slug`), public (`/titles/:slug`), and trial detail pages. Fixes the "Title not found" on real Low titles like `crush-on-you`.
- **Still hidden everywhere else (unlisted model):** lists, search, AI chat, Comps Navigator, Mandate Matcher, Format Fit, and the pitch-deck PDF (`SecurePDFViewer`) keep filtering Low/null — unchanged.
- **Red LOW PRIORITY admin badge** via a reusable `LowPriorityBadge` component, on all admin title surfaces: AdminTitles table, TitleEditModal header, AdminTitleEdit/TitleEdit, Trending (table + picker), WeeklyTitle (selected + picker), and Microdrama/Format Spotlight.
- Plumbed `priority` into the featured, weekly-title, and admin format-spotlight queries so the badge is accurate.
- Updated `titlesService` tests and `docs/active/DATABASE_SCHEMA.md`.

### Also included (already on v2, not yet on main)
- `feat(dashboard): repurpose Microdrama Spotlight to admin-curated section`
- `fix(dashboard): reconcile dev server to port 8081`

## Verification
- `tsc --noEmit` clean, `npm run build:dashboard` clean, `vitest` titlesService green (incl. updated priority tests).
- **Live browser (local, suite/admin test account):**
  - `/buyers/titles/crush-on-you` fully renders (was "Title not found").
  - Public anon `/titles/crush-on-you` renders.
  - Admin table shows red LOW PRIORITY badge on Low titles only (12 non-Low rows confirmed no badge); modal header badge confirmed.

## Note
- Per the chosen scope, Low titles are now reachable by **anyone** via public `/titles/:slug` (no login). Intended "unlisted" behavior, flagging for awareness.
- Staging deploy was skipped due to an outdated local Vercel CLI; production auto-deploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)