### PR TITLE
fix(security): P0-3 phase A — website anon reads via public views (+ rotation helpers)

### DIFF
--- a/apps/website/src/components/SecurePDFViewer.tsx
+++ b/apps/website/src/components/SecurePDFViewer.tsx
@@ -113,9 +113,11 @@ export default function SecurePDFViewer({ pdfUrl, title }: SecurePDFViewerProps)
           // Extract title ID for additional validation
           const titleId = filePath.split('/')[0];
           
-          // Verify title exists in database (additional security layer)
+          // Verify title exists (existence check only; read from the public-safe
+          // view so this works for anonymous visitors without granting anon access
+          // to the raw titles table).
           const { data: titleExists, error: titleError } = await supabase
-            .from('titles')
+            .from('public_titles' as any)
             .select('title_id')
             .eq('title_id', titleId)
             .single();

--- a/apps/website/src/services/formatSpotlightService.ts
+++ b/apps/website/src/services/formatSpotlightService.ts
@@ -49,9 +49,9 @@ export async function getFormatSpotlightData(
   const scoreKey = `${formatType}_score`;
   const analysisKey = `${formatType}_analysis`;
 
-  // title_format_fit is not in the website's generated Supabase types
+  // Read from the public-safe view (anon has no direct grant on title_format_fit).
   const { data: fitData, error: fitError } = await db
-    .from('title_format_fit')
+    .from('public_title_format_fit')
     .select('title_id, film_score, tv_series_score, animation_score, microdrama_score, audio_drama_score, film_analysis, tv_series_analysis, animation_analysis, microdrama_analysis, audio_drama_analysis');
 
   if (fitError) {
@@ -75,8 +75,9 @@ export async function getFormatSpotlightData(
   if (filtered.length === 0) return [];
 
   const titleIds = filtered.map((r) => r.title_id as string);
+  // Read from the public-safe view (anon has no direct grant on titles).
   const { data: titles, error: titlesError } = await db
-    .from('titles')
+    .from('public_titles')
     .select('title_id, title_name_en, title_name_kr, title_image, genre, content_format, tone, story_author, art_author, rating, views')
     .in('title_id', titleIds);
 

--- a/docs/guides/SERVICE_ROLE_KEY_ROTATION_RUNBOOK.md
+++ b/docs/guides/SERVICE_ROLE_KEY_ROTATION_RUNBOOK.md
@@ -1,0 +1,177 @@
+# Service Role Key Rotation — Step-by-Step Runbook
+
+**Goal:** invalidate the leaked `service_role` key (committed to git) without breaking anything, using the reversible new-API-keys path.
+
+**Why:** the old `service_role` JWT bypasses all database security and is sitting in git history. Rotating is the only thing that actually neutralizes it. This guide is written so every step is verifiable and the one irreversible-feeling step is last and undoable.
+
+**Time:** ~45–60 min. Do it in a low-traffic window.
+
+---
+
+## Mental model (read once)
+
+Only three things touch keys:
+
+1. **Your 3 websites** (marketing, dashboard, creator) → use the **anon / publishable** key. Public by design; already in the browser.
+2. **Edge functions + your 4 scripts** → use the **secret / service_role** key. *This is the one that leaked.*
+3. **Logged-in users** → have sessions (unaffected by this path — no forced logout).
+
+The catch: the leaked secret key and the public anon key are "twins" signed by one underlying secret, so you can't disable the leaked one without also retiring the anon key. That's why the frontends also need the new publishable key. It's just swapping one value per app.
+
+**Your safety net:** the health check. Run it after every step.
+```bash
+bash scripts/rotation-healthcheck.sh
+```
+All green = safe to continue. Any red = stop, undo the step you just did, re-run until green.
+
+---
+
+## Phase 0 — Baseline (5 min, no changes)
+
+1. Confirm you can run the check and everything is currently green:
+   ```bash
+   bash scripts/rotation-healthcheck.sh
+   ```
+   Expected: `8 passed, 0 failed — all green`. This is your "known good" state.
+2. Have a password manager / secure note open to paste the new keys into (never commit them).
+3. Know where your env vars live:
+   - **Local:** repo root `.env.local` (has `SUPABASE_SERVICE_ROLE_KEY`), and `apps/{dashboard,creator,website}/.env.local` / `.env.production` (have `VITE_SUPABASE_ANON_KEY`).
+   - **Vercel:** ~5 projects (dashboard prod + staging, creator prod + staging, website). Env vars under each project → **Settings → Environment Variables**.
+
+✅ Checkpoint: baseline is all green.
+
+---
+
+## Phase 1 — Create the new keys (5 min, additive, zero risk)
+
+Nothing breaks here — you're only *creating* keys, not using them yet.
+
+1. Supabase Dashboard → **Settings → API Keys**.
+2. Create a **Publishable key** → copy it (`sb_publishable_…`) into your secure note.
+3. Create a **Secret key** → copy it (`sb_secret_…`) into your secure note.
+4. Leave the **legacy** keys enabled for now.
+
+Verify nothing changed:
+```bash
+bash scripts/rotation-healthcheck.sh      # still uses the OLD anon key
+```
+✅ Checkpoint: still all green (you haven't switched anything yet).
+
+Also test that the **new publishable key works** before you rely on it:
+```bash
+SUPABASE_KEY=sb_publishable_YOURKEYHERE bash scripts/rotation-healthcheck.sh
+```
+✅ Checkpoint: the `public_titles` and `PII blocked` lines are green with the new key. If red, the key was copied wrong — recopy.
+
+---
+
+## Phase 2 — Migrate the SECRET key (backend) (15 min)
+
+The old secret key still works throughout this phase, so mistakes are harmless.
+
+### 2a. Local scripts
+1. In your shell, set the new secret key:
+   ```bash
+   export SUPABASE_SERVICE_ROLE_KEY='sb_secret_YOURKEYHERE'
+   ```
+   Also update the value in repo-root `.env.local`.
+2. Test a script that uses it (read-only diagnostics):
+   ```bash
+   node scripts/diagnose-asset.js
+   ```
+   ✅ Checkpoint: it connects and runs (no auth error). The scripts now refuse to run without this env var — that's intended.
+
+### 2b. Edge functions
+Edge functions receive their service-role key automatically from the Supabase platform — you do **not** paste it into code. When legacy keys are disabled in Phase 4, the platform serves the new secret. You don't change anything here now; you *verify* in Phase 4 and can roll back if needed.
+
+Run the check to confirm nothing regressed:
+```bash
+bash scripts/rotation-healthcheck.sh
+```
+✅ Checkpoint: all green.
+
+---
+
+## Phase 3 — Migrate the PUBLISHABLE key (frontends) (15 min)
+
+Swap the public key in each app. The old anon key still works until Phase 4, so you can do these one at a time and test each.
+
+⚠️ **The key lives in BOTH Vercel env vars AND hardcoded in source files** — the source copies are easy to miss and will break the app on legacy-shutdown if not swapped. All hardcoded source copies have already been swapped to the publishable key on branch `fix/p0-anon-title-exposure` (they still need to be committed + deployed).
+
+| App | Vercel env var | Hardcoded source copies (already swapped on branch) |
+|---|---|---|
+| **Website** | none (source only) | `src/integrations/supabase/client.ts`, `src/utils/slack.ts`, `src/utils/slackNotifications.ts` |
+| **Dashboard** | `VITE_SUPABASE_ANON_KEY` (prod + staging) | `src/services/directApiService.ts`, `src/utils/slack.ts` |
+| **Creator** | `VITE_SUPABASE_ANON_KEY` (prod + staging) | `src/utils/slack.ts` |
+
+So each app needs **both**: the code changes deployed *and* (dashboard/creator) the Vercel env var updated. Old and new keys both work until Phase 4, so order within this phase doesn't matter — just get all of them done before Phase 4.
+
+### 3a. Website (source file, not Vercel)
+1. In `apps/website/src/integrations/supabase/client.ts`, replace the value of `SUPABASE_PUBLISHABLE_KEY` with the new **publishable** key (`sb_publishable_…`). (The file says "automatically generated" — editing it directly is fine here; the generator isn't running.)
+2. Commit and deploy the website (push to `main`, or trigger a Vercel redeploy of the website project).
+3. When live, run `bash scripts/rotation-healthcheck.sh` and open kstorybridge.com to confirm it loads.
+
+### 3b. Dashboard & Creator (Vercel env)
+For **each** of the 4 projects (dashboard prod, dashboard staging, creator prod, creator staging):
+1. Project → **Settings → Environment Variables** → edit `VITE_SUPABASE_ANON_KEY` → paste the new **publishable** key → save.
+   - If a project doesn't have that variable, that app isn't reading from Vercel — check its `src/lib/supabase.ts` to see where it reads from, and tell me.
+2. **Redeploy** that project (Deployments → latest → Redeploy) — Vite bakes the key in at build time, so a redeploy is required.
+3. When it finishes, run `bash scripts/rotation-healthcheck.sh`, then open that site and confirm **sign-in works** with a test account.
+
+### 3c. Local dev
+Update `VITE_SUPABASE_ANON_KEY` in `apps/dashboard/.env.local` and `apps/creator/.env.local` so local dev matches. (The website's local value is the hardcoded one you just edited.)
+
+✅ Checkpoint after all apps: all green **and** you've logged into dashboard + creator successfully in a browser.
+
+---
+
+## Phase 4 — Disable the legacy keys (THE KILL) (5 min, reversible)
+
+This is the step that actually invalidates the leaked key. Everything already runs on the new keys, so this should be a no-op — but it's fully reversible if not.
+
+1. Supabase Dashboard → **Settings → API Keys** → **disable legacy keys**.
+2. Immediately run:
+   ```bash
+   bash scripts/rotation-healthcheck.sh
+   ```
+3. Read the result:
+   - **All green** → 🎉 done, proceed to Phase 5.
+   - **Any red** (most likely an edge-function line) → **re-enable legacy keys** (same screen, one toggle). Within a minute you're back to all-green and nothing is broken. Then tell me which line went red and we fix that surface before retrying.
+
+✅ Checkpoint: all green with legacy keys disabled. (If you had to roll back, that's fine — you're safe, just not done yet.)
+
+---
+
+## Phase 5 — Confirm the leaked key is dead + clean up (5 min)
+
+1. Prove the OLD `service_role` key no longer works. Paste the old key (from git history) into `OLD`:
+   ```bash
+   OLD='eyJ...oldServiceRoleKey...'
+   curl -s -o /dev/null -w "%{http_code}\n" \
+     "https://dlrnrgcoguxlkkcitlpd.supabase.co/rest/v1/user_buyers?select=email&limit=1" \
+     -H "apikey: $OLD" -H "Authorization: Bearer $OLD"
+   ```
+   ✅ Expect **401** (it was 200 with full PII access before). That confirms the leak is neutralized.
+2. Commit the four scripts that no longer contain the hardcoded key (already prepared on branch `fix/p0-anon-title-exposure`):
+   `dangerous-scripts/fix-vector-search.js`, `scripts/create-storage-bucket.js`, `scripts/diagnose-asset.js`, `scripts/make-bucket-public.js`.
+3. **History purge (optional but recommended):** the old key is still in git history. Since it's now rotated and dead, this is cleanup, not urgent. When ready, do a `git filter-repo` pass to remove it (and the PII CSVs) from history — separate task, coordinate first.
+
+---
+
+## If you get stuck / rollback summary
+
+| Situation | Undo |
+|---|---|
+| Something red in Phase 1–3 | The old keys still work; just fix the value you swapped and re-run the check. |
+| Red after disabling legacy (Phase 4) | Re-enable legacy keys (one toggle). Instantly back to working. |
+| A site won't load after redeploy | Its `VITE_SUPABASE_ANON_KEY` is wrong or it wasn't redeployed — re-check the env var and redeploy. |
+| Sign-in broken on a site | Same as above — publishable key mismatch on that project. |
+
+**Golden rule:** never move to the next phase until `bash scripts/rotation-healthcheck.sh` is all green. If in doubt, stop — nothing is lost, and the old keys stay working until Phase 4.
+
+---
+
+## Not covered here (separate tasks)
+
+- **P0-3 anon catalog exposure** — the migration + website code on branch `fix/p0-anon-title-exposure` is a *separate* deploy (RLS/grant issue, not a key issue). Do it after rotation, on its own, using the same health check.
+- **Git history purge** of the old key + PII CSVs — Phase 5 step 3.

--- a/scripts/rotation-healthcheck.sh
+++ b/scripts/rotation-healthcheck.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# rotation-healthcheck.sh — READ-ONLY health check for the key-rotation runbook.
+# Prints a green/red line per surface so you can confirm nothing broke before and
+# after each rotation step. Makes NO writes and deploys nothing.
+#
+# Usage:
+#   bash scripts/rotation-healthcheck.sh                 # uses the anon key in apps/dashboard/.env.local
+#   SUPABASE_KEY=sb_publishable_xxx bash scripts/rotation-healthcheck.sh   # test a NEW publishable key
+#
+# Exit code 0 = all checks passed, 1 = at least one failed.
+
+set -uo pipefail
+export PATH=/usr/bin:/bin:/usr/local/bin
+
+SUPA_URL="https://dlrnrgcoguxlkkcitlpd.supabase.co"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Key to test with: env override, else the anon key from the dashboard app.
+KEY="${SUPABASE_KEY:-}"
+if [ -z "$KEY" ]; then
+  KEY="$(grep -h 'VITE_SUPABASE_ANON_KEY' "$REPO_ROOT/apps/dashboard/.env.local" 2>/dev/null | head -1 | cut -d= -f2)"
+fi
+if [ -z "$KEY" ]; then
+  echo "ERROR: no key found. Set SUPABASE_KEY=... or ensure apps/dashboard/.env.local has VITE_SUPABASE_ANON_KEY."
+  exit 1
+fi
+
+pass=0; fail=0
+GREEN=$'\033[32m'; RED=$'\033[31m'; DIM=$'\033[2m'; RST=$'\033[0m'
+
+ok()   { printf "  ${GREEN}PASS${RST}  %-42s ${DIM}%s${RST}\n" "$1" "$2"; pass=$((pass+1)); }
+bad()  { printf "  ${RED}FAIL${RST}  %-42s ${DIM}%s${RST}\n" "$1" "$2"; fail=$((fail+1)); }
+
+# 1) Public web surfaces should return HTTP 200
+check_http () { # name url
+  local code; code=$(curl -s -o /dev/null -w "%{http_code}" -L --max-time 20 "$2")
+  if [ "$code" = "200" ]; then ok "$1" "HTTP $code"; else bad "$1" "HTTP $code (expected 200)"; fi
+}
+
+# 2) A Supabase REST read that requires a valid public key (anon/publishable)
+check_rest_read () { # name path expect(data|empty)
+  local out code body
+  out=$(curl -s -w $'\n%{http_code}' --max-time 20 "$SUPA_URL/rest/v1/$2" \
+        -H "apikey: $KEY" -H "Authorization: Bearer $KEY")
+  code=$(printf '%s' "$out" | tail -1)
+  body=$(printf '%s' "$out" | sed '$d')
+  if [ "$3" = "data" ]; then
+    if [ "$code" = "200" ] && [ "$body" != "[]" ] && [ -n "$body" ]; then ok "$1" "HTTP $code, rows returned"
+    else bad "$1" "HTTP $code, body=${body:0:40} (expected rows)"; fi
+  else # expect empty/blocked
+    if [ "$code" = "200" ] && [ "$body" = "[]" ]; then ok "$1" "HTTP $code, correctly empty"
+    elif [ "$code" = "401" ] || [ "$code" = "403" ]; then ok "$1" "HTTP $code, correctly blocked"
+    else bad "$1" "HTTP $code, body=${body:0:40} (expected empty/blocked)"; fi
+  fi
+}
+
+# 3) An edge function should be reachable (deployed). 200/401/400 = alive; 404/5xx = broken.
+check_edge_alive () { # name function
+  local code; code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 -X OPTIONS \
+        "$SUPA_URL/functions/v1/$2" -H "apikey: $KEY")
+  case "$code" in
+    200|201|204|400|401|403) ok "$1" "HTTP $code (deployed)";;
+    *) bad "$1" "HTTP $code (expected function to be reachable)";;
+  esac
+}
+
+echo "KStoryBridge rotation health check  ${DIM}(key: ${KEY:0:12}…, read-only)${RST}"
+echo "-----------------------------------------------------------------------"
+echo "Public sites"
+check_http "marketing website"      "https://kstorybridge.com"
+check_http "buyer dashboard"        "https://dashboard.kstorybridge.com"
+check_http "creator app"            "https://creator.kstorybridge.com"
+check_http "public title page"      "https://dashboard.kstorybridge.com/titles/reunion-1"
+echo "Supabase public key (anon/publishable) path"
+check_rest_read "read public_titles view"  "public_titles?select=title_id&limit=1"  data
+check_rest_read "PII stays blocked (user_buyers)" "user_buyers?select=email&limit=1" empty
+echo "Edge functions (secret/service_role path is exercised server-side)"
+check_edge_alive "chat-orchestrator reachable" "chat-orchestrator"
+check_edge_alive "create-checkout-session reachable" "create-checkout-session"
+echo "-----------------------------------------------------------------------"
+printf "Result: ${GREEN}%d passed${RST}, " "$pass"
+if [ "$fail" -gt 0 ]; then printf "${RED}%d FAILED${RST}\n" "$fail"; exit 1
+else printf "0 failed — all green\n"; exit 0; fi

--- a/supabase/migrations/20260703120000_public_format_fit_view.sql
+++ b/supabase/migrations/20260703120000_public_format_fit_view.sql
@@ -1,0 +1,48 @@
+-- Migration: 20260703120000_public_format_fit_view.sql
+-- Created: 2026-07-03
+-- Author: audit remediation (P0-3, phase A)
+-- Status: IN_PROGRESS
+--
+-- Description:
+--   Phase A of closing the anonymous-read exposure of raw `titles` / `title_format_fit`.
+--   Adds a public-safe view `public_title_format_fit` (format scores + analysis only)
+--   so the public Format Spotlight page has a safe source, and grants anon/authenticated
+--   SELECT on it.
+--
+--   This phase is PURELY ADDITIVE — it does NOT revoke anything. Anonymous access to the
+--   raw tables is unchanged, so nothing breaks whether or not the website code is deployed.
+--   The revoke happens in phase B (20260703130000_anon_lockdown.sql) AFTER the website is
+--   confirmed reading the views.
+--
+-- Risk Level: LOW (additive; no data modified, no grants removed)
+-- Destructive: NO
+-- Backup Required: NO
+--
+-- Rollback:
+--   DROP VIEW IF EXISTS public.public_title_format_fit;
+--
+-- Testing:
+--   [ ] Applied to production
+--   [ ] anon can SELECT public_title_format_fit
+--   [ ] Format Spotlight page still works (old code on raw table OR new code on view)
+
+CREATE OR REPLACE VIEW public.public_title_format_fit AS
+SELECT
+  title_id,
+  film_score,
+  tv_series_score,
+  animation_score,
+  microdrama_score,
+  audio_drama_score,
+  film_analysis,
+  tv_series_analysis,
+  animation_analysis,
+  microdrama_analysis,
+  audio_drama_analysis
+FROM public.title_format_fit;
+
+COMMENT ON VIEW public.public_title_format_fit IS
+  'Public-safe projection of title_format_fit for anonymous marketing surfaces (Format Spotlight). Excludes any internal/cost columns.';
+
+GRANT SELECT ON public.public_title_format_fit TO anon;
+GRANT SELECT ON public.public_title_format_fit TO authenticated;


### PR DESCRIPTION
## What
Phase A of closing the anonymous-read exposure of the raw \`titles\` / \`title_format_fit\` tables (audit finding P0-3), plus the key-rotation helper docs/script.

- **Migration \`20260703120000_public_format_fit_view.sql\`** — adds \`public_title_format_fit\` view (public-safe columns) + anon/authenticated grants. **Already applied to prod via SQL editor** (view verified anon-readable, 84 rows).
- **Website code** — \`formatSpotlightService\` and \`SecurePDFViewer\` now read \`public_titles\` / \`public_title_format_fit\` instead of the raw tables.
- **Rotation helpers** — \`SERVICE_ROLE_KEY_ROTATION_RUNBOOK.md\` + \`rotation-healthcheck.sh\`.

## Zero-downtime
Phase A is additive — it does **not** revoke anon's raw-table access. So during/after this deploy, both old code (raw tables) and new code (views) work. The revoke is **Phase B**, applied separately *after* this is live and verified.

## Note: website has no staging
Website only deploys from \`main\`, so this code is verified locally (build + view column match) rather than on staging. Low risk (read-path change to an equivalent view).

## After merge
1. Confirm the Format Spotlight page works in prod (reads the view).
2. Apply Phase B revoke (staged) to close anon access to the raw tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)