### PR TITLE
Lezhin intelligence scraper + hybrid buyer title search

### DIFF
--- a/.claude/skills/title-intelligence/SKILL.md
+++ b/.claude/skills/title-intelligence/SKILL.md
@@ -33,7 +33,13 @@ This skill orchestrates data collection from multiple platforms to gather metric
 | Platform | Domain | Data Collected |
 |----------|--------|----------------|
 | Manta | manta.net | Views, likes, rating |
-| Webtoons | webtoons.com | Views, subscribers, rating |
+| Lezhin Comics | lezhinus.com | Views, subscribers, chapters, tags, genre, authors, synopsis, completed status, cover |
+| Webtoons | webtoons.com | NOT wired into the live edge function — scraper exists only in packages/title-intelligence |
+
+**Lezhin notes:**
+- URL format: `https://www.lezhinus.com/{lang}/comic/{alias}` (legacy lezhin.com also accepted)
+- Data comes from the Next.js flight data embedded in the page HTML (server-rendered)
+- Adult-gated titles require the `LEZHIN_COOKIE` edge function secret — the Cookie header from a logged-in lezhinus.com session with content mode "all". Set via `npx supabase secrets set LEZHIN_COOKIE='...'`. Without it, gated titles return a descriptive error; non-gated titles work without the secret.
 
 ### Fan Engagement Sources
 
@@ -356,6 +362,7 @@ Total views: 21,246,912
 
 ## Related Skills
 
+- `/find-english-release` - Resolve a Korean title URL to its English counterpart (Webtoons, Manta, Lezhin, Tappytoon) before running intelligence collection on the English side
 - `/regenerate-embeddings` - Regenerate after data collection
 - `/health-check` - Verify intelligence system health
 - `/cost-report` - Track collection operations

--- a/apps/dashboard/src/pages/buyers/Titles.tsx
+++ b/apps/dashboard/src/pages/buyers/Titles.tsx
@@ -37,9 +37,12 @@ export default function Titles() {
   const [formatFilteredTitleIds, setFormatFilteredTitleIds] = useState<Set<string> | null>(null);
   const [formatFitSummaries, setFormatFitSummaries] = useState<Map<string, FormatFitSummary>>(new Map());
 
+  const [vectorPending, setVectorPending] = useState(false);
+
   const observerTarget = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const searchCountRef = useRef(0); // Track searches per session for analytics
+  const searchRequestIdRef = useRef(0); // Discard stale search responses
 
   // Track page view on mount
   useEffect(() => {
@@ -95,33 +98,53 @@ export default function Titles() {
     const fetchTitles = async () => {
       setLoading(true);
       setOffset(0); // Reset offset when filters change
+      // Any new fetch invalidates in-flight hybrid search stages
+      searchRequestIdRef.current += 1;
+      setVectorPending(false);
       try {
-        // Use vector search if there's a search query
+        // Use hybrid search if there's a search query:
+        // stage 1 = fast ilike name/synopsis matches, stage 2 = semantic vector results appended
         if (searchQuery && searchQuery.trim().length > 0) {
-          console.log('🔍 Using vector search for:', searchQuery);
+          console.log('🔍 Using hybrid search for:', searchQuery);
+          const requestId = searchRequestIdRef.current;
 
-          // Vector search returns all results at once (no pagination)
-          let vectorResults = await titlesService.searchTitlesVector(searchQuery, 50);
+          const { nameMatches, vectorPromise } = await titlesService.searchTitlesHybrid(searchQuery, 50);
+          if (requestId !== searchRequestIdRef.current) return; // stale
 
           // Apply format filter if set
-          if (formatFilteredTitleIds !== null) {
-            vectorResults = vectorResults.filter((t) => formatFilteredTitleIds.has(t.title_id));
-          }
+          const applyFormatFilter = (list: Title[]) =>
+            formatFilteredTitleIds !== null
+              ? list.filter((t) => formatFilteredTitleIds.has(t.title_id))
+              : list;
 
-          setTitles(vectorResults);
-          setHasMore(false); // Vector search returns all results at once
+          const stage1 = applyFormatFilter(nameMatches);
+          setTitles(stage1);
+          setHasMore(false); // Search returns all results at once (no pagination)
           setOffset(0);
-
-          // Track vector search
-          trackTitleSearch(searchQuery, vectorResults.length, 'vector');
+          setLoading(false); // Show exact matches immediately
+          setVectorPending(true);
 
           // Increment search counter for session analytics
           searchCountRef.current += 1;
 
-          // Track zero results for search quality analysis
-          if (vectorResults.length === 0) {
-            trackSearchZeroResults(searchQuery, 'vector');
-          }
+          // Stage 2: append semantic results (deduped) once ready
+          vectorPromise.then((vectorResults) => {
+            if (requestId !== searchRequestIdRef.current) return; // stale
+            setVectorPending(false);
+
+            const seen = new Set(stage1.map((t) => t.title_id));
+            const additions = applyFormatFilter(vectorResults).filter((t) => !seen.has(t.title_id));
+            const totalCount = stage1.length + additions.length;
+            if (additions.length > 0) {
+              setTitles((prev) => [...prev, ...additions]);
+            }
+
+            trackTitleSearch(searchQuery, totalCount, 'hybrid');
+            // Track zero results for search quality analysis
+            if (totalCount === 0) {
+              trackSearchZeroResults(searchQuery, 'hybrid');
+            }
+          });
         } else if (formatFilteredTitleIds !== null && formatFilter) {
           // Format filter is active - get those specific titles
           const titleIds = Array.from(formatFilteredTitleIds).slice(0, 30);
@@ -169,7 +192,7 @@ export default function Titles() {
     // Debounce search to avoid excessive API calls
     const debounceTimer = setTimeout(() => {
       fetchTitles();
-    }, searchQuery ? 500 : 0); // 500ms debounce for search, instant for filters
+    }, searchQuery ? 300 : 0); // 300ms debounce for search, instant for filters
 
     return () => clearTimeout(debounceTimer);
   }, [searchQuery, formatFilteredTitleIds, toast]);
@@ -285,7 +308,14 @@ export default function Titles() {
           </div>
           {searchQuery && (
             <p className="text-xs text-gray-500 text-center mt-2">
-              Using AI-powered semantic search
+              {vectorPending ? (
+                <span className="inline-flex items-center gap-1.5">
+                  <Icon icon="solar:refresh-bold-duotone" className="h-3.5 w-3.5 animate-spin" />
+                  Finding similar titles with AI…
+                </span>
+              ) : (
+                'Name matches first, AI-powered similar titles below'
+              )}
             </p>
           )}
         </div>

--- a/apps/dashboard/src/services/titlesService.ts
+++ b/apps/dashboard/src/services/titlesService.ts
@@ -828,6 +828,31 @@ class TitlesService {
   }
 
   /**
+   * Hybrid search: fast ilike name/synopsis matching plus semantic vector search.
+   *
+   * Returns the ilike matches immediately (title-name hits ranked first) along
+   * with a pending promise for the vector results so callers can render in two
+   * stages. The vector promise never rejects — semantic search failing must not
+   * break the search experience.
+   */
+  async searchTitlesHybrid(
+    searchQuery: string,
+    vectorLimit: number = 50
+  ): Promise<{ nameMatches: Title[]; vectorPromise: Promise<Title[]> }> {
+    const vectorPromise = this.searchTitlesVector(searchQuery, vectorLimit).catch((error) => {
+      console.error('❌ Vector stage of hybrid search failed:', error);
+      return [] as Title[];
+    });
+
+    const nameMatches = await this.getTitles({
+      search: searchQuery,
+      prioritizeTitleName: true,
+    });
+
+    return { nameMatches, vectorPromise };
+  }
+
+  /**
    * Update a title
    */
   async updateTitle(titleId: string, updates: Partial<Title>): Promise<void> {

--- a/apps/dashboard/src/utils/analytics.ts
+++ b/apps/dashboard/src/utils/analytics.ts
@@ -475,12 +475,12 @@ export const trackSignin = (
  * Track title search actions
  * @param query - Search query text
  * @param resultCount - Number of results returned
- * @param searchType - 'vector' | 'pagination' | 'filter'
+ * @param searchType - 'hybrid' | 'vector' | 'pagination' | 'filter'
  */
 export const trackTitleSearch = (
   query: string,
   resultCount: number,
-  searchType: 'vector' | 'pagination' | 'filter' = 'vector',
+  searchType: 'hybrid' | 'vector' | 'pagination' | 'filter' = 'vector',
   metadata?: Record<string, unknown>
 ): void => {
   trackEvent('title_search', {

--- a/packages/tools/src/services/intelligenceService.ts
+++ b/packages/tools/src/services/intelligenceService.ts
@@ -64,6 +64,8 @@ const PLATFORM_PATTERNS: Record<SupportedPlatform, RegExp> = {
   kakao: /page\.kakao\.com\/content\/(\d+)|page\.kakao\.com\/.*seriesId=(\d+)/,
   kakao_webtoon: /webtoon\.kakao\.com\/content\/[^/]+\/(\d+)/,
   manta: /manta\.net\/.*seriesId=(\d+)/,
+  // Lezhin English site (lezhinus.com) and legacy lezhin.com; alias slug after /comic/
+  lezhin: /lezhin(?:us)?\.com\/[a-z]{2}(?:-[a-z]{2})?\/comic\/([A-Za-z0-9_-]+)/,
   ridibooks: /ridibooks\.com\/books\/(\d+)/,
   // Bomtoon canonical detail path is /detail/{slug}; older /comic/ep_list/{slug}
   // URLs still resolve to the same SPA shell so we accept both.
@@ -80,6 +82,7 @@ export const PLATFORM_DISPLAY_NAMES: Record<SupportedPlatform, string> = {
   kakao: 'Kakao Page',
   kakao_webtoon: 'Kakao Webtoon',
   manta: 'Manta',
+  lezhin: 'Lezhin Comics',
   ridibooks: 'Ridibooks',
   bomtoon: 'Bomtoon',
   unknown: 'Unknown',
@@ -126,7 +129,7 @@ export function parseUrl(url: string): ParsedUrl {
     platformId: null,
     originalUrl: trimmedUrl,
     valid: false,
-    error: 'Unsupported platform. Supported: Naver Webtoon, Naver Series, Kakao Page, Kakao Webtoon, Manta, Ridibooks',
+    error: 'Unsupported platform. Supported: Naver Webtoon, Naver Series, Kakao Page, Kakao Webtoon, Manta, Lezhin Comics, Ridibooks, Bomtoon',
   };
 }
 

--- a/packages/tools/src/types/intelligence.ts
+++ b/packages/tools/src/types/intelligence.ts
@@ -15,6 +15,7 @@ export type SupportedPlatform =
   | 'kakao'
   | 'kakao_webtoon'
   | 'manta'
+  | 'lezhin'
   | 'ridibooks'
   | 'bomtoon'
   | 'unknown';

--- a/supabase/functions/title-intelligence/index.ts
+++ b/supabase/functions/title-intelligence/index.ts
@@ -31,6 +31,7 @@ import { scrapeKakaoWebtoon } from './scrapers/kakao-webtoon.ts'
 import { scrapeManta } from './scrapers/manta.ts'
 import { scrapeRidibooks } from './scrapers/ridibooks.ts'
 import { scrapeBomtoon } from './scrapers/bomtoon.ts'
+import { scrapeLezhin } from './scrapers/lezhin.ts'
 import { scrapeReddit } from './scrapers/reddit.ts'
 import { scrapeAO3 } from './scrapers/ao3.ts'
 import { scrapeComick } from './scrapers/comick.ts'
@@ -52,7 +53,7 @@ interface LegacyIntelligenceRequest {
 // New URL-based request format (can include fan engagement sources)
 interface UrlBasedRequest {
   urls: Array<{
-    platform: 'naver_webtoon' | 'naver_series' | 'kakao' | 'kakao_webtoon' | 'manta' | 'ridibooks' | 'bomtoon'
+    platform: 'naver_webtoon' | 'naver_series' | 'kakao' | 'kakao_webtoon' | 'manta' | 'ridibooks' | 'bomtoon' | 'lezhin'
     platformId: string
     originalUrl: string
     // Naver Series ships comics and novels on the same productNo namespace
@@ -103,6 +104,7 @@ const SOURCE_CATEGORIES: Record<string, string> = {
   'ridibooks': 'official_platform',
   'bomtoon': 'official_platform',
   'manta': 'official_platform_en',
+  'lezhin': 'official_platform_en',
   'webtoons': 'official_platform_en',
   'reddit': 'fandom_forum',
   'ao3': 'fanfiction',
@@ -119,6 +121,7 @@ const SOURCE_DOMAINS: Record<string, string> = {
   'ridibooks': 'ridibooks.com',
   'bomtoon': 'bomtoon.com',
   'manta': 'manta.net',
+  'lezhin': 'lezhinus.com',
   'webtoons': 'webtoons.com',
   'reddit': 'reddit.com',
   'ao3': 'archiveofourown.org',
@@ -316,6 +319,14 @@ async function handleUrlBasedCollection(supabase: any, body: UrlBasedRequest) {
           )
           break
 
+        case 'lezhin':
+          // Use comic alias with Lezhin scraper (with retry)
+          scraperResult = await withRetry(
+            () => scrapeLezhin(urlInfo.platformId),
+            { operationName: `Lezhin scrape (${urlInfo.platformId})`, maxRetries: 2, baseDelayMs: 1000 }
+          )
+          break
+
         case 'bomtoon':
           // Use slug with Bomtoon scraper (with retry)
           scraperResult = await withRetry(
@@ -354,7 +365,7 @@ async function handleUrlBasedCollection(supabase: any, body: UrlBasedRequest) {
         : `https://${urlInfo.originalUrl}`
 
       // Determine region/language based on platform
-      const isEnglishPlatform = urlInfo.platform === 'manta'
+      const isEnglishPlatform = urlInfo.platform === 'manta' || urlInfo.platform === 'lezhin'
       const region = isEnglishPlatform ? 'Global' : 'KR'
       const language = isEnglishPlatform ? 'en' : 'ko'
 

--- a/supabase/functions/title-intelligence/scrapers/lezhin.ts
+++ b/supabase/functions/title-intelligence/scrapers/lezhin.ts
@@ -1,0 +1,293 @@
+/**
+ * Lezhin Comics Scraper (lezhinus.com)
+ *
+ * Purpose: Scrape metadata from Lezhin Comics English site
+ *
+ * Data Collected:
+ * - title_en: display.title
+ * - synopsis_en: display.synopsis
+ * - views: properties.viewCount
+ * - likes: properties.subscriptions (subscriber count)
+ * - genre: genres[]
+ * - tags: properties.tags
+ * - author/artist: artists[] by role (writer vs illustrator)
+ * - chapters: episode count from dehydrated ["episode", alias] query
+ * - completed: state === 'completed'
+ * - age_rating: 'Adult (18+)' when isAdult
+ * - thumbnail: og:image
+ *
+ * Strategy:
+ * 1. Fetch HTML from lezhinus.com/en/comic/{alias} with browser UA
+ *    (+ optional LEZHIN_COOKIE secret for adult-gated titles)
+ * 2. Extract Next.js App Router flight data (self.__next_f.push chunks),
+ *    JS-unescape, locate the "content":{...} object via brace balancing
+ * 3. Fall back to og: meta tags if flight data parsing fails
+ *
+ * Adult-gated titles redirect to /login without a valid session cookie.
+ * Set the LEZHIN_COOKIE secret to the Cookie header of a logged-in
+ * lezhinus.com session (with content mode "all") to collect them.
+ *
+ * URL Format: https://www.lezhinus.com/en/comic/{alias}
+ */
+
+const HEADERS: Record<string, string> = {
+  'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+  'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+  'Accept-Language': 'en-US,en;q=0.9',
+}
+
+interface LezhinData {
+  source: string
+  scraped_at: string
+  title_found: boolean
+  data: {
+    alias: string | null
+    title_en: string | null
+    views: number | null
+    likes: number | null
+    rating: number | null
+    subscribers: number | null
+    chapters: number | null
+    completed: boolean | null
+    platform_url: string | null
+    last_updated: string | null
+    genre: string[] | null
+    author: string | null
+    artist: string | null
+    synopsis_en: string | null
+    age_rating: string | null
+    thumbnail: string | null
+    tags: string[]
+  }
+  metadata: {
+    search_query: string
+    scraping_method: string
+    response_status: number | null
+    error: string | null
+  }
+}
+
+/**
+ * Unescape a JS string literal body (the "..." inside self.__next_f.push([1,"..."]))
+ */
+function unescapeJsString(s: string): string {
+  return s
+    .replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+    .replace(/\\n/g, '\n')
+    .replace(/\\t/g, '\t')
+    .replace(/\\"/g, '"')
+    .replace(/\\\\/g, '\\')
+}
+
+/**
+ * Slice a balanced JSON object starting at the first '{' at/after `from`
+ */
+function sliceBalancedObject(text: string, from: number): string | null {
+  const start = text.indexOf('{', from)
+  if (start === -1) return null
+  let depth = 0
+  let inString = false
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i]
+    if (inString) {
+      if (ch === '\\') i++
+      else if (ch === '"') inString = false
+      continue
+    }
+    if (ch === '"') inString = true
+    else if (ch === '{') depth++
+    else if (ch === '}') {
+      depth--
+      if (depth === 0) return text.substring(start, i + 1)
+    }
+  }
+  return null
+}
+
+/**
+ * Main scraper function for Lezhin Comics
+ * Accepts the comic alias (e.g. "my_own")
+ */
+export async function scrapeLezhin(alias: string): Promise<LezhinData> {
+  console.log(`[Lezhin] Scraping for alias: ${alias}`)
+
+  const result: LezhinData = {
+    source: 'lezhin',
+    scraped_at: new Date().toISOString(),
+    title_found: false,
+    data: {
+      alias: alias,
+      title_en: null,
+      views: null,
+      likes: null,
+      rating: null,
+      subscribers: null,
+      chapters: null,
+      completed: null,
+      platform_url: null,
+      last_updated: null,
+      genre: null,
+      author: null,
+      artist: null,
+      synopsis_en: null,
+      age_rating: null,
+      thumbnail: null,
+      tags: []
+    },
+    metadata: {
+      search_query: alias,
+      scraping_method: 'next_flight_data',
+      response_status: null,
+      error: null
+    }
+  }
+
+  try {
+    const url = `https://www.lezhinus.com/en/comic/${alias}`
+    console.log(`[Lezhin] Fetching: ${url}`)
+
+    const headers = { ...HEADERS }
+    const cookie = Deno.env.get('LEZHIN_COOKIE')
+    if (cookie) {
+      headers['Cookie'] = cookie
+    }
+
+    const response = await fetch(url, { headers, redirect: 'follow' })
+
+    result.metadata.response_status = response.status
+
+    if (!response.ok) {
+      console.error(`[Lezhin] HTTP error: ${response.status}`)
+      result.metadata.error = `HTTP error: ${response.status}`
+      return result
+    }
+
+    result.data.platform_url = url
+
+    const html = await response.text()
+    console.log(`[Lezhin] HTML length: ${html.length}, final URL: ${response.url}`)
+
+    // Adult-gated titles redirect to the login page without a valid session
+    if (response.url.includes('/login') || html.includes('<title>Login - Lezhin')) {
+      result.metadata.error = cookie
+        ? 'Lezhin session cookie expired — refresh the LEZHIN_COOKIE secret (npx supabase secrets set LEZHIN_COOKIE=...)'
+        : 'Adult-gated title requires Lezhin login — set the LEZHIN_COOKIE secret (npx supabase secrets set LEZHIN_COOKIE=...)'
+      return result
+    }
+
+    // Collect and unescape all flight-data chunks
+    const chunks: string[] = []
+    const flightRegex = /self\.__next_f\.push\(\[1,"((?:[^"\\]|\\.)*)"\]\)/g
+    let m: RegExpExecArray | null
+    while ((m = flightRegex.exec(html)) !== null) {
+      chunks.push(unescapeJsString(m[1]))
+    }
+    console.log(`[Lezhin] Flight data chunks: ${chunks.length}`)
+
+    // The comic object lives in the React Query dehydrated state: "content":{...}
+    const flightData = chunks.join('')
+    const contentIdx = flightData.indexOf('"content":{')
+    if (contentIdx !== -1) {
+      const objText = sliceBalancedObject(flightData, contentIdx)
+      if (objText) {
+        try {
+          const content = JSON.parse(objText)
+
+          result.title_found = true
+          result.data.title_en = content.display?.title || null
+          result.data.synopsis_en = content.display?.synopsis || null
+          result.data.views = content.properties?.viewCount ?? null
+          result.data.subscribers = content.properties?.subscriptions ?? null
+          result.data.likes = content.properties?.subscriptions ?? null
+
+          if (Array.isArray(content.genres) && content.genres.length > 0) {
+            result.data.genre = content.genres
+          }
+          if (Array.isArray(content.properties?.tags)) {
+            result.data.tags = content.properties.tags
+          }
+
+          // Artists: role is 'writer' | 'illustrator' | 'scripter' etc.
+          if (Array.isArray(content.artists)) {
+            const writers = content.artists
+              .filter((a: any) => a.role === 'writer' || a.role === 'scripter')
+              .map((a: any) => a.name)
+            const illustrators = content.artists
+              .filter((a: any) => a.role === 'illustrator' || a.role === 'artist' || a.role === 'painter')
+              .map((a: any) => a.name)
+            const all = content.artists.map((a: any) => a.name)
+            result.data.author = writers.length > 0 ? writers.join(', ') : (all.join(', ') || null)
+            result.data.artist = illustrators.length > 0 ? illustrators.join(', ') : (all.join(', ') || null)
+          }
+
+          result.data.completed =
+            content.state === 'completed' ||
+            content.display?.schedule === 'COMPLETED'
+
+          if (content.isAdult === true) {
+            result.data.age_rating = 'Adult (18+)'
+          }
+
+          if (content.updatedAt) {
+            result.data.last_updated = new Date(content.updatedAt).toISOString()
+          }
+        } catch (parseError) {
+          console.error('[Lezhin] Failed to parse content JSON:', parseError)
+          result.metadata.error = `Content JSON parse error: ${parseError.message}`
+        }
+      }
+    } else {
+      console.log('[Lezhin] "content" object not found in flight data')
+      result.metadata.scraping_method = 'og_meta_fallback'
+    }
+
+    // Episode count: the dehydrated ["episode", alias] query embeds the episode
+    // list; each episode has a "name":"<number>" entry.
+    const episodeQueryIdx = flightData.indexOf(`"queryKey":["episode","${alias}"`)
+    if (episodeQueryIdx !== -1) {
+      // Episode list is in the same dehydrated state blob, before the queryKey
+      const episodeNames = flightData.match(/"name":"\d+"/g)
+      if (episodeNames && episodeNames.length > 0) {
+        result.data.chapters = episodeNames.length
+      }
+    }
+
+    // og: meta tags (thumbnail always; title/synopsis as fallback)
+    const ogTitleMatch = html.match(/property="og:title"[^>]*content="([^"]+)"/i) ||
+                        html.match(/content="([^"]+)"[^>]*property="og:title"/i)
+    const ogDescMatch = html.match(/property="og:description"[^>]*content="([^"]+)"/i) ||
+                       html.match(/content="([^"]+)"[^>]*property="og:description"/i)
+    const ogImageMatch = html.match(/property="og:image"[^>]*content="([^"]+)"/i) ||
+                        html.match(/content="([^"]+)"[^>]*property="og:image"/i)
+
+    if (ogImageMatch) {
+      result.data.thumbnail = ogImageMatch[1]
+    }
+    if (!result.data.title_en && ogTitleMatch) {
+      // og:title format: "{Title} - {Artists} - Webtoons - Lezhin Comics"
+      result.data.title_en = ogTitleMatch[1].split(' - ')[0].trim()
+      result.title_found = true
+    }
+    if (!result.data.synopsis_en && ogDescMatch) {
+      result.data.synopsis_en = ogDescMatch[1]
+    }
+
+    console.log(`[Lezhin] Extracted:`, {
+      title: result.data.title_en,
+      views: result.data.views,
+      subscribers: result.data.subscribers,
+      chapters: result.data.chapters,
+      genres: result.data.genre,
+      completed: result.data.completed,
+      author: result.data.author,
+      hasThumb: !!result.data.thumbnail,
+    })
+
+    return result
+
+  } catch (error) {
+    console.error('[Lezhin] Scraping error:', error)
+    result.metadata.error = error.message || 'Unknown error'
+    return result
+  }
+}


### PR DESCRIPTION
## Summary

Two changes, both verified end-to-end:

### 1. Lezhin Comics (lezhinus.com) support in title-intelligence
- New `scrapers/lezhin.ts` — extracts title, synopsis, views, subscribers, chapters, genres, tags, authors, and completed status from the Next.js flight data embedded in comic pages (og: meta fallback)
- Admin panel now accepts `lezhinus.com`/`lezhin.com` comic URLs (URL parsing in `packages/tools`)
- Adult-gated titles work via the `LEZHIN_COOKIE` edge function secret (set with `npx supabase secrets set LEZHIN_COOKIE='...'` from a logged-in browser session); without it they return a descriptive error and non-gated titles work fine
- Edge function already deployed; verified live on `my_own` (524k views, 66 chapters) and `lovekitsch_allages`

### 2. Hybrid buyer title search (/buyers/titles)
Previously every search went through the vector-search edge function (~2s, cosine-ranked), so exact title lookups were slow and could rank below thematically similar titles. Now:
- Fast ilike name-priority search renders immediately (~300ms), semantic vector results append below (deduped), with a request-ID guard against stale responses
- Vector failure no longer breaks search; debounce 500ms → 300ms; tracked as `search_type: 'hybrid'`
- Verified in-browser with the QA account: exact match tops results in <1s, semantic results append after

## Test plan
- [x] `npm run build` passes (dashboard)
- [x] Lint: no new issues vs main
- [x] Live scraper test on gated + non-gated Lezhin titles
- [x] Browser QA of hybrid search (exact, semantic, rapid-retype staleness)
- [ ] Post-merge: set `LEZHIN_COOKIE` secret for adult-gated titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)