### PR TITLE
feat(analytics): establish reliable measurement program

### DIFF
--- a/.github/workflows/analytics-progress.yml
+++ b/.github/workflows/analytics-progress.yml
@@ -1,0 +1,31 @@
+name: Analytics Program Progress
+
+on:
+  schedule:
+    # Monday 08:00 PDT / 07:00 PST. GitHub cron uses UTC.
+    - cron: '0 15 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  progress-audit:
+    name: Report analytics program progress
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate and deliver progress report
+        run: node scripts/analytics-progress-report.mjs --send
+        env:
+          SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}

--- a/apps/creator/src/components/tools/CollectButton.tsx
+++ b/apps/creator/src/components/tools/CollectButton.tsx
@@ -24,6 +24,7 @@ const PLATFORM_ICONS: Record<SupportedPlatform, string> = {
   kakao: 'simple-icons:kakaotalk',
   kakao_webtoon: 'simple-icons:kakaotalk',
   manta: 'solar:book-2-bold-duotone',
+  lezhin: 'solar:book-bold-duotone',
   ridibooks: 'solar:book-bold-duotone',
   bomtoon: 'solar:book-bold-duotone',
   unknown: 'solar:database-bold-duotone',

--- a/apps/creator/src/components/tools/IntelligenceResultsModal.tsx
+++ b/apps/creator/src/components/tools/IntelligenceResultsModal.tsx
@@ -46,6 +46,7 @@ function detectPlatformFromDomain(domain: string): SupportedPlatform {
     return domain.includes('series') ? 'naver_series' : 'naver_webtoon';
   }
   if (domain.includes('manta')) return 'manta';
+  if (domain.includes('lezhin')) return 'lezhin';
   if (domain.includes('ridibooks')) return 'ridibooks';
   if (domain.includes('bomtoon')) return 'bomtoon';
   return 'unknown';

--- a/apps/creator/src/hooks/useAuth.tsx
+++ b/apps/creator/src/hooks/useAuth.tsx
@@ -1,7 +1,11 @@
 import { createContext, useContext, useEffect, useState } from 'react'
 import { User, Session } from '@supabase/supabase-js'
 import { supabase } from '@/lib/supabase'
-import { setAnalyticsUser, clearAnalyticsUser } from '@/utils/analytics'
+import {
+  setAnalyticsUser,
+  clearAnalyticsUser,
+  isInternalTrafficMetadata,
+} from '@/utils/analytics'
 
 interface AuthContextType {
   user: User | null
@@ -56,7 +60,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
         // Set GA4 user ID for cross-session tracking
         if (session?.user) {
-          setAnalyticsUser(session.user.id, { type: 'creator' })
+          setAnalyticsUser(session.user.id, {
+            type: 'creator',
+            internal: isInternalTrafficMetadata(session.user.app_metadata),
+          })
+        } else {
+          clearAnalyticsUser()
         }
       })
     }
@@ -73,7 +82,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       // Update GA4 user tracking on auth state change
       if (session?.user) {
-        setAnalyticsUser(session.user.id, { type: 'creator' })
+        setAnalyticsUser(session.user.id, {
+          type: 'creator',
+          internal: isInternalTrafficMetadata(session.user.app_metadata),
+        })
       } else {
         clearAnalyticsUser()
       }

--- a/apps/creator/src/utils/analytics.ts
+++ b/apps/creator/src/utils/analytics.ts
@@ -17,7 +17,61 @@ declare global {
 // Environment-based configuration
 const GA_MEASUREMENT_ID = import.meta.env.VITE_GA_MEASUREMENT_ID || '';
 const IS_DEV = import.meta.env.DEV;
-const IS_ANALYTICS_ENABLED = !!GA_MEASUREMENT_ID;
+const PRODUCTION_ANALYTICS_HOSTS = new Set(['creator.kstorybridge.com']);
+const NON_PRODUCTION_OVERRIDE_KEY = 'ksb_enable_non_production_analytics';
+
+export const isAnalyticsCollectionAllowed = (
+  hostname: string,
+  allowNonProduction = false
+): boolean => PRODUCTION_ANALYTICS_HOSTS.has(hostname.toLowerCase()) || allowNonProduction;
+
+const hasRuntimeAnalyticsOverride = (): boolean => {
+  if (typeof window === 'undefined') return false;
+
+  const requested = new URLSearchParams(window.location.search).get('analytics_debug') === '1';
+  if (requested) {
+    window.sessionStorage.setItem(NON_PRODUCTION_OVERRIDE_KEY, 'true');
+  }
+
+  return requested || window.sessionStorage.getItem(NON_PRODUCTION_OVERRIDE_KEY) === 'true';
+};
+
+const ALLOW_NON_PRODUCTION_ANALYTICS =
+  import.meta.env.VITE_ENABLE_NON_PRODUCTION_ANALYTICS === 'true' || hasRuntimeAnalyticsOverride();
+const IS_ANALYTICS_ENABLED =
+  !!GA_MEASUREMENT_ID &&
+  typeof window !== 'undefined' &&
+  isAnalyticsCollectionAllowed(window.location.hostname, ALLOW_NON_PRODUCTION_ANALYTICS);
+
+const isInternalHost = (): boolean =>
+  typeof window !== 'undefined' &&
+  (/^(localhost|127\.0\.0\.1)$/.test(window.location.hostname) ||
+    window.location.hostname.includes('-staging.'));
+
+export const isInternalTrafficMetadata = (
+  appMetadata?: Record<string, unknown> | null
+): boolean => appMetadata?.internal_traffic === true;
+
+type AnalyticsTrafficType = 'external' | 'internal';
+type PendingAnalyticsEvent = { eventName: string; params: Record<string, unknown> };
+
+let analyticsIdentityResolved = false;
+let analyticsTrafficType: AnalyticsTrafficType = isInternalHost() ? 'internal' : 'external';
+const pendingAnalyticsEvents: PendingAnalyticsEvent[] = [];
+const MAX_PENDING_ANALYTICS_EVENTS = 100;
+
+const flushPendingAnalyticsEvents = (): void => {
+  if (!IS_ANALYTICS_ENABLED || !analyticsIdentityResolved || typeof window.gtag !== 'function') {
+    return;
+  }
+
+  for (const event of pendingAnalyticsEvents.splice(0)) {
+    window.gtag('event', event.eventName, {
+      ...event.params,
+      traffic_type: analyticsTrafficType,
+    });
+  }
+};
 
 /**
  * Initialize Google Analytics 4
@@ -26,7 +80,11 @@ const IS_ANALYTICS_ENABLED = !!GA_MEASUREMENT_ID;
 export const initializeAnalytics = (): void => {
   if (!IS_ANALYTICS_ENABLED) {
     if (IS_DEV) {
-      console.log('[Analytics] GA4 not configured (VITE_GA_MEASUREMENT_ID not set)');
+      console.log('[Analytics] GA4 disabled for this environment', {
+        measurementConfigured: !!GA_MEASUREMENT_ID,
+        hostname: typeof window !== 'undefined' ? window.location.hostname : 'server',
+        overrideEnabled: ALLOW_NON_PRODUCTION_ANALYTICS,
+      });
     }
     return;
   }
@@ -48,7 +106,9 @@ export const initializeAnalytics = (): void => {
 
   window.gtag('js', new Date());
   window.gtag('config', GA_MEASUREMENT_ID, {
-    send_page_view: true,
+    // Route-level tracking sends page views after auth classification.
+    send_page_view: false,
+    traffic_type: analyticsTrafficType,
   });
 
   if (IS_DEV) {
@@ -71,6 +131,7 @@ export const setAnalyticsUser = (
   userProperties?: {
     tier?: string;
     type?: string;
+    internal?: boolean;
   }
 ): void => {
   if (!IS_ANALYTICS_ENABLED) {
@@ -81,9 +142,14 @@ export const setAnalyticsUser = (
   }
 
   if (typeof window !== 'undefined' && window.gtag) {
-    // Set GA4 User ID for cross-session tracking
+    analyticsTrafficType = userProperties?.internal ? 'internal' : 'external';
+    analyticsIdentityResolved = true;
+
+    // The Supabase UUID is non-PII. Internal classification comes from
+    // service-role-controlled app_metadata, never from an email in the bundle.
     window.gtag('config', GA_MEASUREMENT_ID, {
       user_id: userId,
+      traffic_type: analyticsTrafficType,
     });
 
     // Set user properties for segmentation in reports
@@ -97,6 +163,8 @@ export const setAnalyticsUser = (
     if (IS_DEV) {
       console.log(`[Analytics] User set: ${userId.substring(0, 8)}...`, userProperties);
     }
+
+    flushPendingAnalyticsEvents();
   }
 };
 
@@ -110,14 +178,19 @@ export const clearAnalyticsUser = (): void => {
   }
 
   if (typeof window !== 'undefined' && window.gtag) {
-    // Clear user ID by setting to undefined
+    analyticsTrafficType = isInternalHost() ? 'internal' : 'external';
+    analyticsIdentityResolved = true;
+
     window.gtag('config', GA_MEASUREMENT_ID, {
       user_id: undefined,
+      traffic_type: analyticsTrafficType,
     });
 
     if (IS_DEV) {
       console.log('[Analytics] User cleared');
     }
+
+    flushPendingAnalyticsEvents();
   }
 };
 
@@ -139,8 +212,18 @@ const trackEvent = (eventName: string, params: Record<string, unknown>): void =>
     return;
   }
 
+  if (!analyticsIdentityResolved) {
+    if (pendingAnalyticsEvents.length < MAX_PENDING_ANALYTICS_EVENTS) {
+      pendingAnalyticsEvents.push({ eventName, params: enrichedParams });
+    }
+    return;
+  }
+
   if (typeof window.gtag === 'function') {
-    window.gtag('event', eventName, enrichedParams);
+    window.gtag('event', eventName, {
+      ...enrichedParams,
+      traffic_type: analyticsTrafficType,
+    });
   }
 };
 

--- a/apps/creator/src/utils/analyticsEnvironment.test.ts
+++ b/apps/creator/src/utils/analyticsEnvironment.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { isAnalyticsCollectionAllowed, isInternalTrafficMetadata } from './analytics';
+
+describe('isAnalyticsCollectionAllowed', () => {
+  it('allows the creator production host', () => {
+    expect(isAnalyticsCollectionAllowed('creator.kstorybridge.com')).toBe(true);
+  });
+
+  it.each([
+    'localhost',
+    '127.0.0.1',
+    'creator-staging.kstorybridge.com',
+    'kstorybridge-creator.vercel.app',
+  ])('blocks non-production host %s by default', hostname => {
+    expect(isAnalyticsCollectionAllowed(hostname)).toBe(false);
+  });
+
+  it('allows an explicit non-production override', () => {
+    expect(isAnalyticsCollectionAllowed('localhost', true)).toBe(true);
+  });
+});
+
+describe('isInternalTrafficMetadata', () => {
+  it('trusts only the explicit boolean app_metadata flag', () => {
+    expect(isInternalTrafficMetadata({ internal_traffic: true })).toBe(true);
+    expect(isInternalTrafficMetadata({ internal_traffic: 'true' })).toBe(false);
+    expect(isInternalTrafficMetadata({})).toBe(false);
+    expect(isInternalTrafficMetadata(null)).toBe(false);
+  });
+});

--- a/apps/dashboard/src/hooks/useAuth.test.tsx
+++ b/apps/dashboard/src/hooks/useAuth.test.tsx
@@ -17,6 +17,9 @@ vi.mock('@/lib/supabase', () => ({
 vi.mock('@/utils/analytics', () => ({
   setAnalyticsUser: vi.fn(),
   clearAnalyticsUser: vi.fn(),
+  isInternalTrafficMetadata: vi.fn(
+    (metadata?: Record<string, unknown>) => metadata?.internal_traffic === true
+  ),
 }));
 
 import { supabase } from '@/lib/supabase';
@@ -182,7 +185,10 @@ describe('useAuth', () => {
         expect(screen.getByTestId('loading').textContent).toBe('false');
       });
 
-      expect(setAnalyticsUser).toHaveBeenCalledWith('user-123', { type: 'buyer' });
+      expect(setAnalyticsUser).toHaveBeenCalledWith('user-123', {
+        type: 'buyer',
+        internal: false,
+      });
     });
 
     it('should not set GA4 analytics user when session is null', async () => {
@@ -250,7 +256,10 @@ describe('useAuth', () => {
 
       expect(screen.getByTestId('user').textContent).toBe('test@example.com');
       expect(screen.getByTestId('session').textContent).toBe('exists');
-      expect(setAnalyticsUser).toHaveBeenCalledWith('user-123', { type: 'buyer' });
+      expect(setAnalyticsUser).toHaveBeenCalledWith('user-123', {
+        type: 'buyer',
+        internal: false,
+      });
     });
 
     it('should update state when auth state changes to signed out', async () => {

--- a/apps/dashboard/src/hooks/useAuth.tsx
+++ b/apps/dashboard/src/hooks/useAuth.tsx
@@ -1,7 +1,11 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { User, Session } from '@supabase/supabase-js';
 import { supabase } from '@/lib/supabase';
-import { setAnalyticsUser, clearAnalyticsUser } from '@/utils/analytics';
+import {
+  setAnalyticsUser,
+  clearAnalyticsUser,
+  isInternalTrafficMetadata,
+} from '@/utils/analytics';
 
 interface AuthContextType {
   user: User | null;
@@ -66,12 +70,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
           // Set GA4 user ID for cross-session tracking
           if (session?.user) {
-            setAnalyticsUser(session.user.id, { type: 'buyer' });
+            setAnalyticsUser(session.user.id, {
+              type: 'buyer',
+              internal: isInternalTrafficMetadata(session.user.app_metadata),
+            });
+          } else {
+            clearAnalyticsUser();
           }
         }
       } catch (err: any) {
         console.error('[AuthProvider] Initialization error:', err);
         if (mounted) {
+          clearAnalyticsUser();
           setLoading(false);
           setError(
             err.message?.includes('timed out')
@@ -96,7 +106,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
         // Update GA4 user tracking on auth state change
         if (session?.user) {
-          setAnalyticsUser(session.user.id, { type: 'buyer' });
+          setAnalyticsUser(session.user.id, {
+            type: 'buyer',
+            internal: isInternalTrafficMetadata(session.user.app_metadata),
+          });
         } else {
           clearAnalyticsUser();
         }

--- a/apps/dashboard/src/utils/analytics.ts
+++ b/apps/dashboard/src/utils/analytics.ts
@@ -20,7 +20,61 @@ export interface TrackingEvent {
 // Environment-based configuration
 const GA_MEASUREMENT_ID = import.meta.env.VITE_GA_MEASUREMENT_ID || '';
 const IS_DEV = import.meta.env.DEV;
-const IS_ANALYTICS_ENABLED = !!GA_MEASUREMENT_ID;
+const PRODUCTION_ANALYTICS_HOSTS = new Set(['dashboard.kstorybridge.com']);
+const NON_PRODUCTION_OVERRIDE_KEY = 'ksb_enable_non_production_analytics';
+
+export const isAnalyticsCollectionAllowed = (
+  hostname: string,
+  allowNonProduction = false
+): boolean => PRODUCTION_ANALYTICS_HOSTS.has(hostname.toLowerCase()) || allowNonProduction;
+
+const hasRuntimeAnalyticsOverride = (): boolean => {
+  if (typeof window === 'undefined') return false;
+
+  const requested = new URLSearchParams(window.location.search).get('analytics_debug') === '1';
+  if (requested) {
+    window.sessionStorage.setItem(NON_PRODUCTION_OVERRIDE_KEY, 'true');
+  }
+
+  return requested || window.sessionStorage.getItem(NON_PRODUCTION_OVERRIDE_KEY) === 'true';
+};
+
+const ALLOW_NON_PRODUCTION_ANALYTICS =
+  import.meta.env.VITE_ENABLE_NON_PRODUCTION_ANALYTICS === 'true' || hasRuntimeAnalyticsOverride();
+const IS_ANALYTICS_ENABLED =
+  !!GA_MEASUREMENT_ID &&
+  typeof window !== 'undefined' &&
+  isAnalyticsCollectionAllowed(window.location.hostname, ALLOW_NON_PRODUCTION_ANALYTICS);
+
+const isInternalHost = (): boolean =>
+  typeof window !== 'undefined' &&
+  (/^(localhost|127\.0\.0\.1)$/.test(window.location.hostname) ||
+    window.location.hostname.includes('-staging.'));
+
+export const isInternalTrafficMetadata = (
+  appMetadata?: Record<string, unknown> | null
+): boolean => appMetadata?.internal_traffic === true;
+
+type AnalyticsTrafficType = 'external' | 'internal';
+type PendingAnalyticsEvent = { eventName: string; params: Record<string, unknown> };
+
+let analyticsIdentityResolved = false;
+let analyticsTrafficType: AnalyticsTrafficType = isInternalHost() ? 'internal' : 'external';
+const pendingAnalyticsEvents: PendingAnalyticsEvent[] = [];
+const MAX_PENDING_ANALYTICS_EVENTS = 100;
+
+const flushPendingAnalyticsEvents = (): void => {
+  if (!IS_ANALYTICS_ENABLED || !analyticsIdentityResolved || typeof window.gtag !== 'function') {
+    return;
+  }
+
+  for (const event of pendingAnalyticsEvents.splice(0)) {
+    window.gtag('event', event.eventName, {
+      ...event.params,
+      traffic_type: analyticsTrafficType,
+    });
+  }
+};
 
 /**
  * Initialize Google Analytics 4
@@ -29,7 +83,11 @@ const IS_ANALYTICS_ENABLED = !!GA_MEASUREMENT_ID;
 export const initializeAnalytics = (): void => {
   if (!IS_ANALYTICS_ENABLED) {
     if (IS_DEV) {
-      console.log('[Analytics] GA4 not configured (VITE_GA_MEASUREMENT_ID not set)');
+      console.log('[Analytics] GA4 disabled for this environment', {
+        measurementConfigured: !!GA_MEASUREMENT_ID,
+        hostname: typeof window !== 'undefined' ? window.location.hostname : 'server',
+        overrideEnabled: ALLOW_NON_PRODUCTION_ANALYTICS,
+      });
     }
     return;
   }
@@ -51,7 +109,9 @@ export const initializeAnalytics = (): void => {
 
   window.gtag('js', new Date());
   window.gtag('config', GA_MEASUREMENT_ID, {
-    send_page_view: true,
+    // Route-level tracking sends page views after auth classification.
+    send_page_view: false,
+    traffic_type: analyticsTrafficType,
   });
 
   if (IS_DEV) {
@@ -74,6 +134,7 @@ export const setAnalyticsUser = (
   userProperties?: {
     tier?: string;
     type?: string;
+    internal?: boolean;
   }
 ): void => {
   if (!IS_ANALYTICS_ENABLED) {
@@ -84,9 +145,14 @@ export const setAnalyticsUser = (
   }
 
   if (typeof window !== 'undefined' && window.gtag) {
-    // Set GA4 User ID for cross-session tracking
+    analyticsTrafficType = userProperties?.internal ? 'internal' : 'external';
+    analyticsIdentityResolved = true;
+
+    // The Supabase UUID is non-PII. Internal classification comes from
+    // service-role-controlled app_metadata, never from an email in the bundle.
     window.gtag('config', GA_MEASUREMENT_ID, {
       user_id: userId,
+      traffic_type: analyticsTrafficType,
     });
 
     // Set user properties for segmentation in reports
@@ -100,6 +166,8 @@ export const setAnalyticsUser = (
     if (IS_DEV) {
       console.log(`[Analytics] User set: ${userId.substring(0, 8)}...`, userProperties);
     }
+
+    flushPendingAnalyticsEvents();
   }
 };
 
@@ -113,14 +181,19 @@ export const clearAnalyticsUser = (): void => {
   }
 
   if (typeof window !== 'undefined' && window.gtag) {
-    // Clear user ID by setting to undefined
+    analyticsTrafficType = isInternalHost() ? 'internal' : 'external';
+    analyticsIdentityResolved = true;
+
     window.gtag('config', GA_MEASUREMENT_ID, {
       user_id: undefined,
+      traffic_type: analyticsTrafficType,
     });
 
     if (IS_DEV) {
       console.log('[Analytics] User cleared');
     }
+
+    flushPendingAnalyticsEvents();
   }
 };
 
@@ -142,8 +215,18 @@ const trackEvent = (eventName: string, params: Record<string, unknown>): void =>
     return;
   }
 
+  if (!analyticsIdentityResolved) {
+    if (pendingAnalyticsEvents.length < MAX_PENDING_ANALYTICS_EVENTS) {
+      pendingAnalyticsEvents.push({ eventName, params: enrichedParams });
+    }
+    return;
+  }
+
   if (typeof window.gtag === 'function') {
-    window.gtag('event', eventName, enrichedParams);
+    window.gtag('event', eventName, {
+      ...enrichedParams,
+      traffic_type: analyticsTrafficType,
+    });
   }
 };
 
@@ -1842,5 +1925,6 @@ declare global {
 export const analyticsConfig = {
   isEnabled: IS_ANALYTICS_ENABLED,
   isDev: IS_DEV,
+  allowNonProduction: ALLOW_NON_PRODUCTION_ANALYTICS,
   measurementId: GA_MEASUREMENT_ID ? `${GA_MEASUREMENT_ID.substring(0, 5)}...` : 'Not configured',
 };

--- a/apps/dashboard/src/utils/analyticsEnvironment.test.ts
+++ b/apps/dashboard/src/utils/analyticsEnvironment.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { isAnalyticsCollectionAllowed, isInternalTrafficMetadata } from './analytics';
+
+describe('isAnalyticsCollectionAllowed', () => {
+  it('allows the buyer production host', () => {
+    expect(isAnalyticsCollectionAllowed('dashboard.kstorybridge.com')).toBe(true);
+  });
+
+  it.each([
+    'localhost',
+    '127.0.0.1',
+    'dashboard-staging.kstorybridge.com',
+    'kstorybridge-dashboard.vercel.app',
+  ])('blocks non-production host %s by default', hostname => {
+    expect(isAnalyticsCollectionAllowed(hostname)).toBe(false);
+  });
+
+  it('allows an explicit non-production override', () => {
+    expect(isAnalyticsCollectionAllowed('localhost', true)).toBe(true);
+  });
+});
+
+describe('isInternalTrafficMetadata', () => {
+  it('trusts only the explicit boolean app_metadata flag', () => {
+    expect(isInternalTrafficMetadata({ internal_traffic: true })).toBe(true);
+    expect(isInternalTrafficMetadata({ internal_traffic: 'true' })).toBe(false);
+    expect(isInternalTrafficMetadata({})).toBe(false);
+    expect(isInternalTrafficMetadata(null)).toBe(false);
+  });
+});

--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -15,20 +15,40 @@
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
     <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-PZBC4XQT');</script>
+    <script>
+    // Production-only by default. Add ?analytics_debug=1 to explicitly enable
+    // analytics for the current non-production browser session.
+    var ksbAnalyticsOverrideKey = 'ksb_enable_non_production_analytics';
+    var ksbInternalTrafficKey = 'ksb_internal_analytics_traffic';
+    var ksbAnalyticsDebugRequested = new URLSearchParams(location.search).get('analytics_debug') === '1';
+    var ksbInternalTrafficRequested = new URLSearchParams(location.search).get('analytics_internal') === '1';
+    if (ksbAnalyticsDebugRequested) {
+      sessionStorage.setItem(ksbAnalyticsOverrideKey, 'true');
+    }
+    if (ksbInternalTrafficRequested) {
+      localStorage.setItem(ksbInternalTrafficKey, 'true');
+    }
+    window.KSB_ANALYTICS_INTERNAL = localStorage.getItem(ksbInternalTrafficKey) === 'true';
+    window.KSB_ANALYTICS_ENABLED = /^(www\.)?kstorybridge\.com$/.test(location.hostname) ||
+      sessionStorage.getItem(ksbAnalyticsOverrideKey) === 'true';
+
+    if (window.KSB_ANALYTICS_ENABLED) {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({ traffic_type: window.KSB_ANALYTICS_INTERNAL ? 'internal' : 'external' });
+      window.gtag = window.gtag || function(){ window.dataLayer.push(arguments); };
+      window.gtag('set', { traffic_type: window.KSB_ANALYTICS_INTERNAL ? 'internal' : 'external' });
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-PZBC4XQT');
+    }
+    </script>
     <!-- End Google Tag Manager -->
 
   </head>
 
   <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PZBC4XQT"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/apps/website/src/components/AnalyticsProvider.tsx
+++ b/apps/website/src/components/AnalyticsProvider.tsx
@@ -1,12 +1,15 @@
 import { useEffect } from 'react';
 import { useAnalytics } from '@/hooks/useAnalytics';
-import { initGA } from '@/utils/analytics';
+import { initGA, initializeEmailLandingEngagement } from '@/utils/analytics';
 
 export default function AnalyticsProvider() {
   // Initialize analytics on mount
   useEffect(() => {
     initGA();
+    const cleanupEmailEngagement = initializeEmailLandingEngagement();
     console.log('📊 Website analytics initialized');
+
+    return cleanupEmailEngagement;
   }, []);
 
   // Use the analytics hook to track page views

--- a/apps/website/src/utils/analytics.ts
+++ b/apps/website/src/utils/analytics.ts
@@ -3,16 +3,103 @@
 declare global {
   interface Window {
     gtag?: (...args: any[]) => void;
-    dataLayer: any[];
+    dataLayer?: any[];
+    KSB_ANALYTICS_ENABLED?: boolean;
+    KSB_ANALYTICS_INTERNAL?: boolean;
   }
 }
 
 // Google Tag Manager Container ID
 const GTM_CONTAINER_ID = 'GTM-PZBC4XQT';
 
+export const isAnalyticsCollectionAllowed = (
+  hostname: string,
+  allowNonProduction = false
+): boolean => /^(www\.)?kstorybridge\.com$/i.test(hostname) || allowNonProduction;
+
+const isAnalyticsEnabled = (): boolean =>
+  typeof window !== 'undefined' && window.KSB_ANALYTICS_ENABLED === true;
+
+export interface EmailCampaignAttribution {
+  campaignSource: string;
+  campaignMedium: string;
+  campaignName: string;
+}
+
+const sanitizeCampaignValue = (value: string | null): string =>
+  (value || 'not_set')
+    .trim()
+    .slice(0, 100)
+    .replace(/[^a-zA-Z0-9._-]+/g, '_');
+
+/**
+ * Returns only campaign-level attribution. Recipient IDs, email addresses,
+ * arbitrary query parameters, and utm_content are intentionally excluded.
+ */
+export const getEmailCampaignAttribution = (
+  search: string
+): EmailCampaignAttribution | null => {
+  const params = new URLSearchParams(search);
+  const source = (params.get('utm_source') || '').toLowerCase();
+  const medium = (params.get('utm_medium') || '').toLowerCase();
+  const isEmailCampaign =
+    medium === 'email' ||
+    medium === 'newsletter' ||
+    /(^|[-_.])(email|newsletter|brevo|sendinblue)([-_.]|$)/.test(source);
+
+  if (!isEmailCampaign) return null;
+
+  return {
+    campaignSource: sanitizeCampaignValue(source),
+    campaignMedium: sanitizeCampaignValue(medium),
+    campaignName: sanitizeCampaignValue(params.get('utm_campaign')),
+  };
+};
+
+/**
+ * Records a conservative human-email-engagement signal only after a trusted
+ * pointer, keyboard, or scroll interaction on an email-attributed landing.
+ * A scanner page load by itself never satisfies this measure.
+ */
+export const initializeEmailLandingEngagement = (): (() => void) => {
+  if (!isAnalyticsEnabled() || typeof window === 'undefined' || !window.dataLayer) {
+    return () => undefined;
+  }
+
+  const attribution = getEmailCampaignAttribution(window.location.search);
+  if (!attribution) return () => undefined;
+
+  let recorded = false;
+  const eventTypes: Array<keyof WindowEventMap> = ['pointerdown', 'keydown', 'scroll'];
+
+  const recordEngagement = (event: Event): void => {
+    if (recorded || !event.isTrusted) return;
+    recorded = true;
+
+    window.dataLayer?.push({
+      event: 'email_landing_engaged',
+      campaign_source: attribution.campaignSource,
+      campaign_medium: attribution.campaignMedium,
+      campaign_name: attribution.campaignName,
+      landing_path: window.location.pathname,
+      engagement_method: event.type,
+      app_section: 'website',
+      traffic_type: window.KSB_ANALYTICS_INTERNAL ? 'internal' : 'external',
+    });
+
+    eventTypes.forEach(type => window.removeEventListener(type, recordEngagement));
+  };
+
+  eventTypes.forEach(type => window.addEventListener(type, recordEngagement, { passive: true }));
+
+  return () => {
+    eventTypes.forEach(type => window.removeEventListener(type, recordEngagement));
+  };
+};
+
 // Initialize Google Tag Manager (GTM is loaded directly in HTML)
 export const initGA = () => {
-  if (typeof window !== 'undefined' && window.dataLayer) {
+  if (isAnalyticsEnabled() && window.dataLayer) {
     // GTM is initialized via the script in HTML
     // Push initial configuration to dataLayer
     window.dataLayer.push({
@@ -26,7 +113,7 @@ export const initGA = () => {
 
 // Track page views
 export const trackPageView = (path: string, title?: string) => {
-  if (typeof window !== 'undefined' && window.dataLayer) {
+  if (isAnalyticsEnabled() && window.dataLayer) {
     window.dataLayer.push({
       'event': 'page_view',
       'page_title': title || document.title,
@@ -39,7 +126,7 @@ export const trackPageView = (path: string, title?: string) => {
 
 // Track custom events
 export const trackEvent = (action: string, category: string, label?: string, value?: number) => {
-  if (typeof window !== 'undefined' && window.dataLayer) {
+  if (isAnalyticsEnabled() && window.dataLayer) {
     window.dataLayer.push({
       'event': 'custom_event',
       'event_action': action,
@@ -68,7 +155,7 @@ export const trackButtonClick = (buttonName: string, location: string) => {
 
 // Track signup events
 export const trackSignup = (userType: 'buyer' | 'creator', method?: string) => {
-  if (typeof window !== 'undefined' && window.dataLayer) {
+  if (isAnalyticsEnabled() && window.dataLayer) {
     window.dataLayer.push({
       'event': 'sign_up',
       'method': method || 'email',
@@ -80,7 +167,7 @@ export const trackSignup = (userType: 'buyer' | 'creator', method?: string) => {
 
 // Track login events
 export const trackLogin = (method?: string) => {
-  if (typeof window !== 'undefined' && window.dataLayer) {
+  if (isAnalyticsEnabled() && window.dataLayer) {
     window.dataLayer.push({
       'event': 'login',
       'method': method || 'email',

--- a/apps/website/src/utils/analyticsEnvironment.test.ts
+++ b/apps/website/src/utils/analyticsEnvironment.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getEmailCampaignAttribution,
+  isAnalyticsCollectionAllowed,
+} from './analytics';
+
+describe('isAnalyticsCollectionAllowed', () => {
+  it.each(['kstorybridge.com', 'www.kstorybridge.com'])(
+    'allows website production host %s',
+    hostname => {
+      expect(isAnalyticsCollectionAllowed(hostname)).toBe(true);
+    }
+  );
+
+  it.each([
+    'localhost',
+    '127.0.0.1',
+    'website-staging.kstorybridge.com',
+    'kstorybridge-website.vercel.app',
+  ])('blocks non-production host %s by default', hostname => {
+    expect(isAnalyticsCollectionAllowed(hostname)).toBe(false);
+  });
+
+  it('allows an explicit non-production override', () => {
+    expect(isAnalyticsCollectionAllowed('localhost', true)).toBe(true);
+  });
+});
+
+describe('getEmailCampaignAttribution', () => {
+  it('recognizes an explicitly tagged email campaign', () => {
+    expect(
+      getEmailCampaignAttribution(
+        '?utm_source=brevo&utm_medium=email&utm_campaign=buyer-weekly'
+      )
+    ).toEqual({
+      campaignSource: 'brevo',
+      campaignMedium: 'email',
+      campaignName: 'buyer-weekly',
+    });
+  });
+
+  it('does not classify ordinary referral or paid traffic as email', () => {
+    expect(getEmailCampaignAttribution('?utm_source=linkedin&utm_medium=social')).toBeNull();
+    expect(getEmailCampaignAttribution('?utm_source=google&utm_medium=cpc')).toBeNull();
+  });
+
+  it('does not return recipient identifiers or arbitrary campaign parameters', () => {
+    const attribution = getEmailCampaignAttribution(
+      '?utm_source=newsletter&utm_medium=email&utm_campaign=July%20Buyers' +
+        '&utm_content=person@example.com&contact_id=secret'
+    );
+
+    expect(attribution).toEqual({
+      campaignSource: 'newsletter',
+      campaignMedium: 'email',
+      campaignName: 'July_Buyers',
+    });
+    expect(JSON.stringify(attribution)).not.toContain('example.com');
+    expect(JSON.stringify(attribution)).not.toContain('secret');
+  });
+});

--- a/docs/active/ANALYTICS_RELIABILITY_EXECUTION_PLAN.md
+++ b/docs/active/ANALYTICS_RELIABILITY_EXECUTION_PLAN.md
@@ -233,6 +233,7 @@ All of the following must be true:
 | 2026-07-13 | Deployed the clean-production `funnel-report-cron` and completed its manual production acceptance run. | Deployment uploaded the function and shared filter; endpoint health returned HTTP 200; seven-day run delivered to three admins and Slack with zero delivery failures. | Observe seven complete production days through 2026-07-20 and evaluate `AR-106` on or after 2026-07-21. |
 | 2026-07-13 | Activated a local weekly progress cron fallback without releasing unrelated `v2` commits. | Idempotent crontab entry at Monday 08:05; wrapper dry run and live delivery both succeeded; three admin emails and Slack delivered. | Keep the fallback active until `AR-014` is merged and its scheduled run is verified. |
 | 2026-07-13 | Classified the authoritative active-admin subset as internal traffic without maintaining a frontend email list. | Three script tests pass; dry run matched 3/3 active admins; protected auth metadata update and verification reported 3/3 internal. | Refresh admin sessions, verify a tagged event after the frontend release, and identify any additional accounts under `AR-005`. |
+| 2026-07-13 | Recorded and pushed the scoped analytics implementation without staging unrelated workspace changes. | `v2` commit `7c9803d0`; push to `origin/v2` succeeded. | Release and validate the three frontend apps separately; do not merge unrelated `v2` product commits solely to activate the workflow. |
 
 ## Progress update procedure
 

--- a/docs/active/ANALYTICS_RELIABILITY_EXECUTION_PLAN.md
+++ b/docs/active/ANALYTICS_RELIABILITY_EXECUTION_PLAN.md
@@ -88,6 +88,7 @@ The initial GA4 audit covered June 13 through July 12, 2026, compared with May 1
 - [ ] `AR-110` Release and validate the conservative `email_landing_engaged` website event; implementation and automated tests are complete, but production website deployment is pending.
 - [x] `AR-111` Classify every active database administrator as internal traffic through protected auth metadata and verify the resulting state.
 - [x] `AR-112` Release dashboard and creator analytics gating to staging and verify committed bundle markers plus root/auth smoke tests.
+- [x] `AR-113` Prove runtime network behavior on all three staging/preview apps: zero analytics by default and intentional collection only with the diagnostic override.
 
 ### Phase 1 acceptance criteria
 
@@ -124,7 +125,12 @@ Implemented 2026-07-13:
 - Active administrators must refresh their session or sign in again before the new claim is present in frontend analytics events. `AR-005` and `AR-109` remain open for any non-admin staff, contractor, investor, and automated-test accounts.
 - Dashboard and creator staging deployments for commit `60cd75b1` reached `READY`. Both custom-domain root and sign-in routes returned HTTP 200, and the served JavaScript bundles contain the app-specific production hostname, `analytics_debug`, the non-production override key, and `internal_traffic` handling.
 - The pre-existing creator build blocker was resolved by completing the Lezhin platform icon/detection mapping; the full creator TypeScript and Vite production build now passes.
-- A clean website preview was attempted twice from an isolated worktree, but Vercel left both deployments in `UNKNOWN` without build logs. The processes and temporary worktree were cleaned up; `AR-110` remains pending rather than treating the website as released.
+- Two initial clean website preview attempts appeared as `UNKNOWN` without build logs. Their processes and temporary worktree were cleaned up rather than treating either attempt as released.
+- Investigation showed the two website attempts were actually `BLOCKED`, not hung: Vercel rejected manual deployments attributed to Git author `noreply@anthropic.com`, which is not a member of the Hobby-plan team. The CLI version displayed that newer state as `UNKNOWN`.
+- A metadata-free export of committed `73bcf109` removed only the unsupported Git attribution. Vercel accepted and built preview `kstorybridge-website-cndahjcti-creepyblues-9060s-projects.vercel.app` to `READY`; the temporary export and downloaded environment file were removed afterward.
+- Dashboard staging was missing `VITE_GA_MEASUREMENT_ID`. The public measurement ID was added to its Development, Preview, and Production environments, and committed `60cd75b1` was redeployed to `READY`.
+- Headless runtime network verification passed: dashboard, creator, and website preview made zero GTM/GA requests by default; each contacted GTM/GA only with `?analytics_debug=1` in a fresh browser context.
+- On the website preview, a trusted pointer interaction on a tagged email landing emitted exactly one `email_landing_engaged` event with sanitized campaign-level fields. `utm_content`, contact identifiers, and email addresses were absent. Production website release remains pending under `AR-110`.
 - The Analytics Admin API does not expose GA4 data-filter administration. The filter must therefore be inspected manually in GA Admin; no filter was activated because activation permanently affects future collected data. Reference: [GA4 data filters](https://support.google.com/analytics/answer/13296761?hl=en) and [internal traffic setup](https://support.google.com/analytics/answer/10104470?hl=en-419).
 
 ### Scheduled-report filter implementation
@@ -239,6 +245,7 @@ All of the following must be true:
 | 2026-07-13 | Classified the authoritative active-admin subset as internal traffic without maintaining a frontend email list. | Three script tests pass; dry run matched 3/3 active admins; protected auth metadata update and verification reported 3/3 internal. | Refresh admin sessions, verify a tagged event after the frontend release, and identify any additional accounts under `AR-005`. |
 | 2026-07-13 | Recorded and pushed the scoped analytics implementation without staging unrelated workspace changes. | `v2` commit `7c9803d0`; push to `origin/v2` succeeded. | Release and validate the three frontend apps separately; do not merge unrelated `v2` product commits solely to activate the workflow. |
 | 2026-07-13 | Released and smoke-tested dashboard and creator analytics gating on staging. | Vercel `READY` deployments from `60cd75b1`; four custom-domain route checks returned 200; deployed bundle markers verified for both apps; all three local app builds pass. | Resolve the website preview deployment state, then perform runtime network validation before production release. |
+| 2026-07-13 | Resolved the website preview block and completed cross-app runtime analytics validation. | Vercel API identified `TEAM_ACCESS_REQUIRED`; metadata-free committed export reached `READY`; six default/override browser cases passed; trusted email interaction emitted one sanitized event. | Create a focused production release path, verify GA Admin filter state, and keep `AR-110` pending until production website validation. |
 
 ## Progress update procedure
 

--- a/docs/active/ANALYTICS_RELIABILITY_EXECUTION_PLAN.md
+++ b/docs/active/ANALYTICS_RELIABILITY_EXECUTION_PLAN.md
@@ -1,0 +1,245 @@
+# Analytics Reliability and User Behavior Program
+
+<!-- analytics-program:status=ACTIVE -->
+
+**Status:** ACTIVE
+**Started:** 2026-07-13
+**Owner:** KStoryBridge leadership and product engineering
+**Review cadence:** Weekly, Monday at 08:00 America/Los_Angeles
+**Source of truth:** This document
+
+## Objective
+
+Build a trustworthy measurement system that shows whether KStoryBridge attracts the right buyers and creators, activates them around real product value, retains them at the expected business cadence, and converts activity into buyer interest and revenue.
+
+The program is complete only when the exit criteria at the end of this document pass and the status marker above is changed from `ACTIVE` to `DONE`.
+
+## Baseline
+
+The initial GA4 audit covered June 13 through July 12, 2026, compared with May 14 through June 12, 2026.
+
+- 533 of 692 raw sessions in the latest period, or 77%, came from a Brevo security-scanner referral.
+- After excluding observed Brevo scanner domains and non-production hosts, the estimate was 45 active users, 143 sessions, 72 engaged sessions, and a 50.3% engagement rate.
+- The bot-excluded audience decreased from 75 to 45 active users, while engaged sessions increased from 53 to 72.
+- The buyer dashboard had 10 active users; 9 returning users generated 55 sessions with 65% engagement.
+- Meaningful buyer activity was concentrated among 2 to 7 users: 49 title-detail views from 7 users, 19 searches from 4 users, 6 chat messages from 3 users, and one title-interest submission.
+- The creator app had 4 active users and 7 sessions in the latest 30 days. Across 90 days, one user generated four draft-save events and no completed title-submission outcome was recorded.
+- Dashboard `signup` and `signin` events combine views, attempts, completions, and errors. The `action` parameter is not registered as a GA custom dimension, so completed auth conversion cannot be reported.
+- No reliable GA event currently connects product use to completed signup, title approval, subscription, or other server-confirmed business outcomes.
+
+## Working principles
+
+1. Server-confirmed business records are authoritative; GA explains behavior around them.
+2. Production, staging, localhost, staff, automated QA, and security scanners must be separable.
+3. An event name represents one outcome. Funnel stages are not hidden only in an unregistered parameter.
+4. Buyer and creator activation are defined before implementation.
+5. Retention is measured at the natural business cadence, not assumed to be daily SaaS usage.
+6. A phase advances only when its acceptance criteria pass.
+
+## Decisions required from the founder
+
+- [ ] `AR-001` Select the primary 90-day business goal: buyer acquisition, buyer activation, recurring buyer usage, buyer-interest generation, creator/title supply, or paid conversion.
+- [ ] `AR-002` Define buyer activation as one explicit, measurable outcome.
+- [ ] `AR-003` Define creator activation as one explicit, measurable outcome.
+- [ ] `AR-004` Define the expected buyer and creator return cadence used for retention.
+- [ ] `AR-005` Provide the staff, admin, contractor, investor, and automated-test accounts or email domains that must be excluded.
+- [ ] `AR-006` Confirm where each authoritative outcome lives: signup, approved buyer, creator profile, title submission, title approval, buyer interest, introduction, trial, and subscription.
+- [ ] `AR-007` Confirm whether the product is currently self-serve, high-touch, or intentionally hybrid.
+- [ ] `AR-008` Reconcile the June 17, June 24, and July 8 Brevo sends with delivered, unique-click, and human-click totals.
+
+## Phase 0: Program setup
+
+- [x] `AR-010` Capture the initial 30-day and 90-day GA4 baseline.
+- [x] `AR-011` Document the execution sequence, acceptance criteria, and progress log.
+- [x] `AR-012` Add a read-only progress-report script.
+- [x] `AR-013` Add a scheduled weekly progress audit and manual dispatch.
+- [ ] `AR-014` Merge the tracker workflow to the default branch so GitHub's schedule activates.
+- [x] `AR-015` Install and verify a local weekly cron fallback until the default-branch workflow is active.
+
+### Phase 0 acceptance criteria
+
+- The plan is in version control and has one unambiguous status marker.
+- `npm run analytics:progress` reports completed and pending tasks without changing product data.
+- The scheduled workflow runs on Mondays and can also be run manually.
+- Weekly delivery uses existing Supabase secrets and the `send-analytics-report` function.
+
+### Progress scheduling state
+
+- Durable repository schedule: `.github/workflows/analytics-progress.yml`, Monday at 15:00 UTC, pending `AR-014` because GitHub only schedules workflows from the default branch.
+- Active fallback: the macOS user crontab runs `scripts/run-analytics-progress-cron.zsh --send` Mondays at 08:05 local time.
+- Fallback log: `~/Library/Logs/KStoryBridge/analytics-progress-cron.log`.
+- The wrapper uses Node's `--env-file` parser rather than shell-sourcing `.env.local`, so secrets containing shell-sensitive characters are preserved exactly.
+- The crontab entry contains no credentials. Delivery uses the existing dashboard environment file and stops automatically when the plan status marker becomes `DONE`.
+- The host cron daemon (`com.vix.cron`) was verified running after installation, and the wrapper is executable.
+- Manual end-to-end verification succeeded on 2026-07-13: the wrapper parsed the plan and delivered to three admins plus Slack with zero failures.
+
+## Phase 1: Clean measurement inputs
+
+- [x] `AR-100` Inventory every GA/GTM initialization path across website, dashboard, and creator.
+- [x] `AR-101` Prevent analytics collection on localhost and staging unless an explicit development override is enabled.
+- [ ] `AR-102` Define and implement internal/test traffic identification for staff, admins, and automated QA.
+- [x] `AR-103` Centralize the observed Brevo/Sendinblue scanner-source filter in all automated GA reports.
+- [ ] `AR-104` Add a human email-engagement measure and reconcile it with Brevo campaign reporting so legitimate clicks are not lost with scanner filtering.
+- [x] `AR-105` Update the existing funnel-report cron to exclude non-production and scanner traffic.
+- [ ] `AR-106` Verify seven consecutive days of production reporting contain no localhost or staging sessions and no scanner-driven alert.
+- [x] `AR-107` Deploy the filtered funnel-report function and verify one manual production run before beginning `AR-106`.
+- [ ] `AR-108` Verify the GA Admin internal-traffic data filter exists and is in Testing mode before any decision to activate it.
+- [ ] `AR-109` After founder approval of `AR-005`, mark approved authenticated accounts with service-role-controlled `app_metadata.internal_traffic=true` and validate a test event.
+- [ ] `AR-110` Release and validate the conservative `email_landing_engaged` website event; implementation and automated tests are complete, but production website deployment is pending.
+- [x] `AR-111` Classify every active database administrator as internal traffic through protected auth metadata and verify the resulting state.
+
+### Phase 1 acceptance criteria
+
+- Automated reports default to production hosts and documented scanner exclusions.
+- Staff/test activity is independently reportable and excluded from customer KPIs.
+- Email campaign reports distinguish scanner opens/clicks from meaningful human engagement.
+- Raw-versus-clean traffic variance is visible in the weekly report.
+
+### Analytics initialization inventory
+
+Completed 2026-07-13:
+
+- Website SPA: `apps/website/index.html` owns GTM container `GTM-PZBC4XQT`; `AnalyticsProvider` and the route hook use its data layer.
+- Website static teaser pages: the English and Korean teaser HTML files each own a gated copy of `GTM-PZBC4XQT` and push lead-submission events.
+- Buyer dashboard: `apps/dashboard/src/main.tsx` calls the direct-gTag `initializeAnalytics()` implementation, now restricted to `dashboard.kstorybridge.com` unless an explicit development override is enabled.
+- Creator app: `apps/creator/src/main.tsx` uses the same direct-gTag pattern, restricted to `creator.kstorybridge.com` unless explicitly overridden.
+- Dashboard legacy: the archived app still contains unconditional GTM initialization. It is excluded from implementation scope unless it is discovered to be deployed or receiving production traffic.
+- Scheduled reporting: `funnel-report-cron` queries the shared GA property without production-host, internal-user, or Brevo-scanner exclusions and expects several event names that production is not emitting.
+- Production-host allowlists are implemented in all current apps and static teaser pages. `?analytics_debug=1` is the explicit session-scoped non-production override used for intentional diagnostics.
+
+### Environment and internal-traffic implementation
+
+Implemented 2026-07-13:
+
+- Production collection is allowlisted to `kstorybridge.com`, `www.kstorybridge.com`, `dashboard.kstorybridge.com`, and `creator.kstorybridge.com`; localhost and staging do not collect by default.
+- Dashboard and creator resolve authentication before sending queued events, preventing anonymous page views from being emitted before the account can be classified.
+- Authenticated internal classification reads only the boolean `app_metadata.internal_traffic` claim. No email address, email pattern, or domain list is shipped in the frontend bundle or sent to GA.
+- Website and static teaser pages support `?analytics_internal=1` for intentional staff QA, persisting the internal classification locally for that browser.
+- Every emitted dashboard and creator event includes `traffic_type=internal|external`; GA `user_id` continues to use the Supabase UUID and is cleared at sign-out.
+- Twenty-seven dashboard tests, seven creator analytics-environment tests, and seven website analytics-environment tests pass. Dashboard and website production builds pass; the creator Vite bundle passes. The creator full TypeScript build remains blocked by the unrelated pre-existing `CollectButton.tsx` platform-map error.
+- `AR-102` remains open until the founder supplies the approved accounts under `AR-005`, those accounts are marked server-side under `AR-109`, and the GA filter is verified under `AR-108`.
+- `scripts/internal-traffic-admins.mjs` derives candidates from active `admin` records, masks output, refuses partial auth matches, preserves existing app metadata, and requires a confirmation token before writing.
+- The 2026-07-13 production run found three active admins, matched all three to auth users, set `app_metadata.internal_traffic=true`, and verified all three updates. No email addresses are stored in the script or plan.
+- Active administrators must refresh their session or sign in again before the new claim is present in frontend analytics events. `AR-005` and `AR-109` remain open for any non-admin staff, contractor, investor, and automated-test accounts.
+- The Analytics Admin API does not expose GA4 data-filter administration. The filter must therefore be inspected manually in GA Admin; no filter was activated because activation permanently affects future collected data. Reference: [GA4 data filters](https://support.google.com/analytics/answer/13296761?hl=en) and [internal traffic setup](https://support.google.com/analytics/answer/10104470?hl=en-419).
+
+### Scheduled-report filter implementation
+
+Completed 2026-07-13:
+
+- `supabase/functions/_shared/analytics-filters.ts` is the source of truth for the three production hosts and all observed Brevo/Sendinblue scanner referral domains.
+- Funnel, page, landing-page, and traffic-source queries in `funnel-report-cron` use the clean production filter.
+- Separate raw-production and clean-production summaries preserve visibility into excluded traffic instead of hiding the data-quality problem.
+- The generated report alerts when more than 10% of production-host sessions are excluded and displays raw versus clean sessions, users, and engaged sessions.
+- `node --test supabase/functions/_shared/analytics-filters.test.mjs` passes all three filter-shape and composition tests.
+- Before the 2026-07-13 deployment, these source changes did not affect the production function.
+- Production deployment completed on 2026-07-13. The endpoint passed an HTTP 200 health check, and a manual seven-day run completed with five alerts and successful delivery to three admins plus Slack.
+- The existing Supabase `weekly-funnel-report` pg_cron job is active as job 1 on schedule `0 14 * * 1` (Monday 14:00 UTC), verified through the production `check_cron_job_status` RPC.
+- The `AR-106` observation window begins with the first full production day after deployment (2026-07-14) and can be closed no earlier than 2026-07-21 after reviewing seven complete days.
+
+### Human email-engagement implementation
+
+Implemented in source on 2026-07-13; production release pending under `AR-110`:
+
+- Email-attributed website landings are recognized only from campaign-level `utm_source`, `utm_medium`, and `utm_campaign` values.
+- `email_landing_engaged` fires only after a browser marks a pointer, keyboard, or scroll interaction as trusted. A redirect or scanner page load alone cannot emit the event.
+- Recipient identifiers, email addresses, `utm_content`, and arbitrary query parameters are neither retained nor sent to GA.
+- The scheduled funnel report now displays event and user totals for this conservative on-site signal so they can be compared with Brevo delivered and unique human-click totals.
+- Ten website analytics tests and the website production build pass. Reconciliation remains open under `AR-104` until the campaign totals requested in `AR-008` are available.
+
+## Phase 2: Define and normalize the event contract
+
+- [ ] `AR-200` Create one shared analytics event contract for all three apps, with owners, triggers, required parameters, and examples.
+- [ ] `AR-201` Replace aggregate buyer auth events with explicit outcomes: `signup_viewed`, `signup_attempted`, `signup_completed`, `signup_failed`, and corresponding sign-in events.
+- [ ] `AR-202` Normalize creator auth names to the same contract and instrument `creator_profile_completed`.
+- [ ] `AR-203` Instrument the founder-approved buyer activation event.
+- [ ] `AR-204` Instrument the founder-approved creator activation event.
+- [ ] `AR-205` Instrument server-confirmed commercial outcomes: interest submitted, introduction requested/completed, checkout started, and subscription started where applicable.
+- [ ] `AR-206` Normalize tool events for title search, title detail, chat, comps, mandates, favorites, and pitch-deck use.
+- [ ] `AR-207` Add automated tests proving each critical event fires once, at the correct successful outcome, with no sensitive data.
+- [ ] `AR-208` Register only the GA custom dimensions needed for analysis and document their retention implications.
+
+### Phase 2 acceptance criteria
+
+- Every funnel stage can be queried by event name without relying on an unregistered action parameter.
+- Successful auth and commercial events fire only after the server confirms success.
+- Website, buyer, and creator event naming is consistent.
+- Event tests pass in all affected apps.
+
+## Phase 3: Connect behavior to authoritative outcomes
+
+- [ ] `AR-300` Set GA `user_id` after authenticated sessions and clear it at sign-out without sending email or other personal data.
+- [ ] `AR-301` Create a documented mapping from GA events to Supabase source-of-truth tables and timestamps.
+- [ ] `AR-302` Build a reconciliation report for successful buyer and creator signups.
+- [ ] `AR-303` Build a reconciliation report for creator title draft, submission, approval, and publication.
+- [ ] `AR-304` Build a reconciliation report for buyer interest, introductions, and Stripe subscription outcomes.
+- [ ] `AR-305` Define cohorts that exclude staff/test users and calculate buyer and creator activation rates.
+- [ ] `AR-306` Calculate retention at the cadence selected in `AR-004` using authenticated external users and meaningful return actions.
+
+### Phase 3 acceptance criteria
+
+- GA completed conversions reconcile with authoritative records within 5%, with every difference explainable.
+- Retention cohorts contain authenticated external users only.
+- No personally identifiable information is sent to GA.
+- Buyer and creator activation can be segmented by source and cohort.
+
+## Phase 4: Reporting, alerts, and operating cadence
+
+- [ ] `AR-400` Replace obsolete funnel event names in the analytics skill and scheduled funnel report.
+- [ ] `AR-401` Produce one weekly acquisition, activation, engagement, retention, and commercial-outcome report.
+- [ ] `AR-402` Add app-specific breakdowns for website, buyer dashboard, and creator app.
+- [ ] `AR-403` Add alerts for scanner share, missing events, reconciliation drift, acquisition decline, activation decline, and retention decline.
+- [ ] `AR-404` Add a compact leadership scorecard with the selected north-star metric and leading indicators.
+- [ ] `AR-405` Verify email and Slack delivery to active admins for two consecutive scheduled runs.
+
+### Phase 4 acceptance criteria
+
+- Every weekly report clearly separates raw traffic, clean external traffic, and internal/test activity.
+- The report connects acquisition to activation, retention, and a business outcome.
+- Alerts are actionable and link to an owner or remediation task.
+- Two consecutive scheduled reports complete without data-quality warnings or delivery failures.
+
+## Phase 5: Validation and closeout
+
+- [ ] `AR-500` Run a two-week validation period after all production instrumentation is deployed.
+- [ ] `AR-501` Review sample user journeys against GA, Supabase, and Stripe records.
+- [ ] `AR-502` Resolve every open reconciliation or instrumentation defect.
+- [ ] `AR-503` Establish baseline targets for the selected north star, activation, and retention metrics.
+- [ ] `AR-504` Record the final architecture, event dictionary, dashboard links, and operating owner.
+- [ ] `AR-505` Obtain founder sign-off that the measurement system answers the business questions.
+- [ ] `AR-506` Change `analytics-program:status=ACTIVE` to `analytics-program:status=DONE`; the scheduled audit will then exit without sending further progress reports.
+
+## Program exit criteria
+
+All of the following must be true:
+
+- All `AR-*` tasks are checked, except tasks explicitly marked not applicable with a documented founder decision.
+- Production customer KPIs exclude scanner, staging, localhost, staff, admin, and automated-test traffic.
+- Buyer and creator activation definitions are documented and measurable.
+- Completed signups and commercial events reconcile with authoritative records within 5%.
+- Retention is reported for authenticated external cohorts at the approved cadence.
+- Two consecutive weekly reports run successfully and reach email and Slack.
+- The founder confirms the scorecard reflects the current business model.
+
+## Progress log
+
+| Date | Change | Evidence | Next action |
+|---|---|---|---|
+| 2026-07-13 | Established baseline and diagnosed Brevo scanner contamination, weak acquisition, concentrated buyer engagement, and missing conversion instrumentation. | GA4 property `496541587`; internal analytics report sent to three admins and Slack. | Answer `AR-001` through `AR-008`, then begin Phase 1. |
+| 2026-07-13 | Added the living plan, progress script, and weekly scheduled audit. | `npm run analytics:progress`; `.github/workflows/analytics-progress.yml`. | Review the plan and merge the workflow to `main`. |
+| 2026-07-13 | Completed the analytics initialization inventory across all three apps, static teaser pages, legacy code, and scheduled reporting. | Initialization inventory under Phase 1; source references listed there. | Review the pre-existing internal-traffic changes, then implement `AR-101`. |
+| 2026-07-13 | Centralized the clean-production GA4 filters and applied them to every scheduled funnel-report query, with a raw-versus-clean guardrail. | Three shared-filter tests pass; function and helper syntax checks pass. | Deploy and manually verify under `AR-107`. |
+| 2026-07-13 | Completed production-host collection gating and implemented privacy-safe, auth-aware internal-traffic tagging. | 41 targeted tests pass; dashboard and website builds plus creator Vite bundle pass. | Approve internal accounts (`AR-005`), inspect the GA filter (`AR-108`), then flag and validate accounts (`AR-109`). |
+| 2026-07-13 | Deployed the clean-production `funnel-report-cron` and completed its manual production acceptance run. | Deployment uploaded the function and shared filter; endpoint health returned HTTP 200; seven-day run delivered to three admins and Slack with zero delivery failures. | Observe seven complete production days through 2026-07-20 and evaluate `AR-106` on or after 2026-07-21. |
+| 2026-07-13 | Activated a local weekly progress cron fallback without releasing unrelated `v2` commits. | Idempotent crontab entry at Monday 08:05; wrapper dry run and live delivery both succeeded; three admin emails and Slack delivered. | Keep the fallback active until `AR-014` is merged and its scheduled run is verified. |
+| 2026-07-13 | Classified the authoritative active-admin subset as internal traffic without maintaining a frontend email list. | Three script tests pass; dry run matched 3/3 active admins; protected auth metadata update and verification reported 3/3 internal. | Refresh admin sessions, verify a tagged event after the frontend release, and identify any additional accounts under `AR-005`. |
+
+## Progress update procedure
+
+When a task is completed:
+
+1. Change its checkbox from `[ ]` to `[x]` only after the phase acceptance evidence exists.
+2. Add one row to the progress log with the evidence and next action.
+3. Run `npm run analytics:progress` locally.
+4. Commit the plan update with the implementation it describes.
+5. Do not mark the program `DONE` until every exit criterion passes and the founder approves closeout.

--- a/docs/active/ANALYTICS_RELIABILITY_EXECUTION_PLAN.md
+++ b/docs/active/ANALYTICS_RELIABILITY_EXECUTION_PLAN.md
@@ -87,6 +87,7 @@ The initial GA4 audit covered June 13 through July 12, 2026, compared with May 1
 - [ ] `AR-109` After founder approval of `AR-005`, mark approved authenticated accounts with service-role-controlled `app_metadata.internal_traffic=true` and validate a test event.
 - [ ] `AR-110` Release and validate the conservative `email_landing_engaged` website event; implementation and automated tests are complete, but production website deployment is pending.
 - [x] `AR-111` Classify every active database administrator as internal traffic through protected auth metadata and verify the resulting state.
+- [x] `AR-112` Release dashboard and creator analytics gating to staging and verify committed bundle markers plus root/auth smoke tests.
 
 ### Phase 1 acceptance criteria
 
@@ -121,6 +122,9 @@ Implemented 2026-07-13:
 - `scripts/internal-traffic-admins.mjs` derives candidates from active `admin` records, masks output, refuses partial auth matches, preserves existing app metadata, and requires a confirmation token before writing.
 - The 2026-07-13 production run found three active admins, matched all three to auth users, set `app_metadata.internal_traffic=true`, and verified all three updates. No email addresses are stored in the script or plan.
 - Active administrators must refresh their session or sign in again before the new claim is present in frontend analytics events. `AR-005` and `AR-109` remain open for any non-admin staff, contractor, investor, and automated-test accounts.
+- Dashboard and creator staging deployments for commit `60cd75b1` reached `READY`. Both custom-domain root and sign-in routes returned HTTP 200, and the served JavaScript bundles contain the app-specific production hostname, `analytics_debug`, the non-production override key, and `internal_traffic` handling.
+- The pre-existing creator build blocker was resolved by completing the Lezhin platform icon/detection mapping; the full creator TypeScript and Vite production build now passes.
+- A clean website preview was attempted twice from an isolated worktree, but Vercel left both deployments in `UNKNOWN` without build logs. The processes and temporary worktree were cleaned up; `AR-110` remains pending rather than treating the website as released.
 - The Analytics Admin API does not expose GA4 data-filter administration. The filter must therefore be inspected manually in GA Admin; no filter was activated because activation permanently affects future collected data. Reference: [GA4 data filters](https://support.google.com/analytics/answer/13296761?hl=en) and [internal traffic setup](https://support.google.com/analytics/answer/10104470?hl=en-419).
 
 ### Scheduled-report filter implementation
@@ -234,6 +238,7 @@ All of the following must be true:
 | 2026-07-13 | Activated a local weekly progress cron fallback without releasing unrelated `v2` commits. | Idempotent crontab entry at Monday 08:05; wrapper dry run and live delivery both succeeded; three admin emails and Slack delivered. | Keep the fallback active until `AR-014` is merged and its scheduled run is verified. |
 | 2026-07-13 | Classified the authoritative active-admin subset as internal traffic without maintaining a frontend email list. | Three script tests pass; dry run matched 3/3 active admins; protected auth metadata update and verification reported 3/3 internal. | Refresh admin sessions, verify a tagged event after the frontend release, and identify any additional accounts under `AR-005`. |
 | 2026-07-13 | Recorded and pushed the scoped analytics implementation without staging unrelated workspace changes. | `v2` commit `7c9803d0`; push to `origin/v2` succeeded. | Release and validate the three frontend apps separately; do not merge unrelated `v2` product commits solely to activate the workflow. |
+| 2026-07-13 | Released and smoke-tested dashboard and creator analytics gating on staging. | Vercel `READY` deployments from `60cd75b1`; four custom-domain route checks returned 200; deployed bundle markers verified for both apps; all three local app builds pass. | Resolve the website preview deployment state, then perform runtime network validation before production release. |
 
 ## Progress update procedure
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "test:e2e:chatbot": "playwright test chatbot.spec.ts",
     "test:e2e:creator": "playwright test creator.spec.ts",
     "test:e2e:report": "playwright show-report",
+    "analytics:progress": "node scripts/analytics-progress-report.mjs",
+    "analytics:internal-admins": "node --env-file=.env.local scripts/internal-traffic-admins.mjs",
     "clean": "turbo run clean",
     "clean:all": "turbo run clean",
     "storybook": "npm run storybook --workspace=packages/storybook",

--- a/scripts/analytics-progress-report.mjs
+++ b/scripts/analytics-progress-report.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+
+import { appendFile, readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const PLAN_PATH = resolve('docs/active/ANALYTICS_RELIABILITY_EXECUTION_PLAN.md')
+const args = new Set(process.argv.slice(2))
+const shouldSend = args.has('--send')
+
+const plan = await readFile(PLAN_PATH, 'utf8')
+const statusMatch = plan.match(/<!--\s*analytics-program:status=(ACTIVE|DONE)\s*-->/)
+
+if (!statusMatch) {
+  throw new Error('Missing analytics program status marker in execution plan')
+}
+
+const programStatus = statusMatch[1]
+const phasePattern = /^## (Phase \d+:[^\n]+)$/gm
+const taskPattern = /^- \[([ xX])\] `?(AR-\d+)`? (.+)$/gm
+const phases = [...plan.matchAll(phasePattern)].map(match => ({
+  name: match[1],
+  index: match.index,
+}))
+
+const tasks = [...plan.matchAll(taskPattern)].map(match => {
+  const phase = [...phases].reverse().find(candidate => candidate.index < match.index)
+  return {
+    id: match[2],
+    description: match[3],
+    complete: match[1].toLowerCase() === 'x',
+    phase: phase?.name ?? 'Decisions required from the founder',
+  }
+})
+
+if (tasks.length === 0) {
+  throw new Error('No AR tasks found in execution plan')
+}
+
+const completed = tasks.filter(task => task.complete)
+const pending = tasks.filter(task => !task.complete)
+const percent = Math.round((completed.length / tasks.length) * 100)
+const byPhase = new Map()
+
+for (const task of tasks) {
+  const phase = byPhase.get(task.phase) ?? { complete: 0, total: 0 }
+  phase.total += 1
+  phase.complete += task.complete ? 1 : 0
+  byPhase.set(task.phase, phase)
+}
+
+const reportLines = [
+  '# KStoryBridge Analytics Program Progress',
+  '',
+  `**Status:** ${programStatus}`,
+  `**Progress:** ${completed.length}/${tasks.length} tasks (${percent}%)`,
+  '',
+  '## Phase progress',
+  '',
+  '| Phase | Complete | Progress |',
+  '|---|---:|---:|',
+]
+
+for (const [phase, counts] of byPhase) {
+  reportLines.push(`| ${phase} | ${counts.complete}/${counts.total} | ${Math.round((counts.complete / counts.total) * 100)}% |`)
+}
+
+reportLines.push('', '## Next pending tasks', '')
+
+for (const task of pending.slice(0, 10)) {
+  reportLines.push(`- **${task.id}:** ${task.description}`)
+}
+
+if (pending.length > 10) {
+  reportLines.push(`- ...and ${pending.length - 10} additional pending tasks.`)
+}
+
+const report = `${reportLines.join('\n')}\n`
+console.log(report)
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  await appendFile(process.env.GITHUB_STEP_SUMMARY, report)
+}
+
+if (programStatus === 'DONE') {
+  console.log('Program is DONE; scheduled delivery is disabled by the plan status marker.')
+  process.exit(0)
+}
+
+if (!shouldSend) {
+  process.exit(0)
+}
+
+const supabaseUrl = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY ?? process.env.VITE_SUPABASE_ANON_KEY
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('SUPABASE_URL/SUPABASE_ANON_KEY (or their VITE_ equivalents) are required with --send')
+}
+
+const response = await fetch(`${supabaseUrl}/functions/v1/send-analytics-report`, {
+  method: 'POST',
+  headers: {
+    Authorization: `Bearer ${supabaseAnonKey}`,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    reportType: 'weekly',
+    reportDate: new Intl.DateTimeFormat('en-US', {
+      dateStyle: 'long',
+      timeZone: 'America/Los_Angeles',
+    }).format(new Date()),
+    reportMarkdown: report,
+    alerts: pending.length > 0
+      ? [`Analytics reliability program has ${pending.length} pending tasks`]
+      : [],
+    sendSlack: true,
+  }),
+})
+
+const responseText = await response.text()
+
+if (!response.ok) {
+  throw new Error(`Progress report delivery failed (${response.status}): ${responseText}`)
+}
+
+console.log(`Progress report delivered: ${responseText}`)

--- a/scripts/internal-traffic-admins.mjs
+++ b/scripts/internal-traffic-admins.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
+
+const APPLY_CONFIRMATION = 'MARK_ACTIVE_ADMINS_INTERNAL'
+
+export const normalizeEmail = email => email.trim().toLowerCase()
+
+export const maskEmail = email => {
+  const [local = '', domain = 'unknown'] = normalizeEmail(email).split('@')
+  return `${local.slice(0, 1) || '*'}***@${domain}`
+}
+
+export const buildAdminCandidates = (adminRows, authUsers) => {
+  const authByEmail = new Map(
+    authUsers
+      .filter(user => typeof user.email === 'string')
+      .map(user => [normalizeEmail(user.email), user])
+  )
+
+  return adminRows.map(admin => {
+    const email = normalizeEmail(admin.email)
+    const authUser = authByEmail.get(email)
+
+    return {
+      email,
+      maskedEmail: maskEmail(email),
+      authUserId: authUser?.id ?? null,
+      currentlyInternal: authUser?.app_metadata?.internal_traffic === true,
+      appMetadata: authUser?.app_metadata ?? {},
+    }
+  })
+}
+
+const requestJson = async (url, serviceRoleKey, path, options = {}) => {
+  const response = await fetch(`${url}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${serviceRoleKey}`,
+      apikey: serviceRoleKey,
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  })
+
+  const body = await response.text()
+  if (!response.ok) {
+    throw new Error(`${options.method ?? 'GET'} ${path} failed (${response.status}): ${body}`)
+  }
+
+  return body ? JSON.parse(body) : null
+}
+
+const listAllAuthUsers = async (url, serviceRoleKey) => {
+  const users = []
+  const perPage = 1000
+
+  for (let page = 1; ; page += 1) {
+    const result = await requestJson(
+      url,
+      serviceRoleKey,
+      `/auth/v1/admin/users?page=${page}&per_page=${perPage}`
+    )
+    const pageUsers = result?.users ?? []
+    users.push(...pageUsers)
+
+    if (pageUsers.length < perPage) return users
+  }
+}
+
+const main = async () => {
+  const args = new Set(process.argv.slice(2))
+  const apply = args.has('--apply-admins')
+  const confirmed = args.has(`--confirm=${APPLY_CONFIRMATION}`)
+  const supabaseUrl = process.env.SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required')
+  }
+
+  if (apply && !confirmed) {
+    throw new Error(
+      `Refusing to modify auth metadata without --confirm=${APPLY_CONFIRMATION}`
+    )
+  }
+
+  const [adminRows, authUsers] = await Promise.all([
+    requestJson(
+      supabaseUrl,
+      serviceRoleKey,
+      '/rest/v1/admin?select=email&active=eq.true&order=email.asc'
+    ),
+    listAllAuthUsers(supabaseUrl, serviceRoleKey),
+  ])
+  const candidates = buildAdminCandidates(adminRows ?? [], authUsers)
+
+  console.log(`Active admin records: ${candidates.length}`)
+  console.log(`Matched auth users: ${candidates.filter(candidate => candidate.authUserId).length}`)
+  console.log(`Already internal: ${candidates.filter(candidate => candidate.currentlyInternal).length}`)
+  console.table(
+    candidates.map(candidate => ({
+      account: candidate.maskedEmail,
+      auth_match: Boolean(candidate.authUserId),
+      internal_traffic: candidate.currentlyInternal,
+    }))
+  )
+
+  if (!apply) {
+    console.log(
+      `Dry run only. Apply with --apply-admins --confirm=${APPLY_CONFIRMATION}`
+    )
+    return
+  }
+
+  const unmatched = candidates.filter(candidate => !candidate.authUserId)
+  if (unmatched.length > 0) {
+    throw new Error(
+      `Refusing partial apply: ${unmatched.length} active admin record(s) have no matching auth user`
+    )
+  }
+
+  let updated = 0
+  for (const candidate of candidates) {
+    if (candidate.currentlyInternal) continue
+
+    await requestJson(
+      supabaseUrl,
+      serviceRoleKey,
+      `/auth/v1/admin/users/${candidate.authUserId}`,
+      {
+        method: 'PUT',
+        body: JSON.stringify({
+          app_metadata: {
+            ...candidate.appMetadata,
+            internal_traffic: true,
+          },
+        }),
+      }
+    )
+    updated += 1
+  }
+
+  console.log(`Updated auth users: ${updated}`)
+  console.log('Users must refresh their session or sign in again before the new claim reaches GA.')
+}
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (isMain) await main()

--- a/scripts/internal-traffic-admins.test.mjs
+++ b/scripts/internal-traffic-admins.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildAdminCandidates,
+  maskEmail,
+  normalizeEmail,
+} from './internal-traffic-admins.mjs'
+
+test('normalizes and masks email without exposing the local part', () => {
+  assert.equal(normalizeEmail(' Admin@KStoryBridge.com '), 'admin@kstorybridge.com')
+  assert.equal(maskEmail('Admin@KStoryBridge.com'), 'a***@kstorybridge.com')
+})
+
+test('matches active admin records to auth users case-insensitively', () => {
+  const candidates = buildAdminCandidates(
+    [{ email: 'Admin@KStoryBridge.com' }],
+    [{
+      id: 'user-1',
+      email: 'admin@kstorybridge.com',
+      app_metadata: { account_type: 'buyer' },
+    }]
+  )
+
+  assert.deepEqual(candidates, [{
+    email: 'admin@kstorybridge.com',
+    maskedEmail: 'a***@kstorybridge.com',
+    authUserId: 'user-1',
+    currentlyInternal: false,
+    appMetadata: { account_type: 'buyer' },
+  }])
+})
+
+test('detects existing internal metadata and missing auth users', () => {
+  const candidates = buildAdminCandidates(
+    [{ email: 'one@example.com' }, { email: 'missing@example.com' }],
+    [{
+      id: 'user-1',
+      email: 'one@example.com',
+      app_metadata: { internal_traffic: true },
+    }]
+  )
+
+  assert.equal(candidates[0].currentlyInternal, true)
+  assert.equal(candidates[1].authUserId, null)
+})

--- a/scripts/run-analytics-progress-cron.zsh
+++ b/scripts/run-analytics-progress-cron.zsh
@@ -1,0 +1,17 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+REPO_ROOT="${0:A:h:h}"
+cd "$REPO_ROOT"
+
+NODE_BIN="${NODE_BIN:-/opt/homebrew/bin/node}"
+if [[ ! -x "$NODE_BIN" ]]; then
+  NODE_BIN="$(command -v node)"
+fi
+
+MODE="${1:---send}"
+exec "$NODE_BIN" \
+  --env-file=apps/dashboard/.env.local \
+  scripts/analytics-progress-report.mjs \
+  "$MODE"

--- a/supabase/functions/_shared/analytics-filters.test.mjs
+++ b/supabase/functions/_shared/analytics-filters.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  BREVO_SCANNER_SOURCE_MEDIUMS,
+  PRODUCTION_ANALYTICS_HOSTS,
+  buildCleanProductionFilter,
+  buildProductionHostFilter,
+} from './analytics-filters.ts'
+
+test('production host filter includes only the three production apps', () => {
+  assert.deepEqual(
+    buildProductionHostFilter().filter.inListFilter.values,
+    PRODUCTION_ANALYTICS_HOSTS
+  )
+  assert.equal(PRODUCTION_ANALYTICS_HOSTS.includes('localhost'), false)
+  assert.equal(PRODUCTION_ANALYTICS_HOSTS.some(host => host.includes('staging')), false)
+})
+
+test('clean filter excludes every observed Brevo scanner source', () => {
+  const filter = buildCleanProductionFilter()
+  const scannerExpressions = filter.andGroup.expressions[1].notExpression.orGroup.expressions
+  const excludedSources = scannerExpressions.map(expression => expression.filter.stringFilter.value)
+
+  assert.deepEqual(excludedSources, BREVO_SCANNER_SOURCE_MEDIUMS)
+  assert.ok(scannerExpressions.every(expression =>
+    expression.filter.fieldName === 'sessionSourceMedium' &&
+    expression.filter.stringFilter.matchType === 'EXACT'
+  ))
+})
+
+test('clean filter appends query-specific conditions without mutating inputs', () => {
+  const eventFilter = {
+    filter: {
+      fieldName: 'eventName',
+      inListFilter: { values: ['trial_page_view'], caseSensitive: true },
+    },
+  }
+  const filter = buildCleanProductionFilter([eventFilter])
+
+  assert.equal(filter.andGroup.expressions.length, 3)
+  assert.deepEqual(filter.andGroup.expressions[2], eventFilter)
+  assert.deepEqual(eventFilter.filter.inListFilter.values, ['trial_page_view'])
+})

--- a/supabase/functions/_shared/analytics-filters.ts
+++ b/supabase/functions/_shared/analytics-filters.ts
@@ -1,0 +1,57 @@
+export const PRODUCTION_ANALYTICS_HOSTS = [
+  'kstorybridge.com',
+  'dashboard.kstorybridge.com',
+  'creator.kstorybridge.com',
+]
+
+// Security scanners have used multiple Brevo/Sendinblue redirect domains over
+// time. Keep this list centralized so every scheduled report uses the same
+// historical exclusions.
+export const BREVO_SCANNER_SOURCE_MEDIUMS = [
+  'lu001.r.sp1-brevo.net / referral',
+  'lu001.r.a.d.sendibm1.com / referral',
+  'lu001.r.bh.d.sendibt3.com / referral',
+]
+
+export type GA4FilterExpression = Record<string, unknown>
+
+export function buildProductionHostFilter(): GA4FilterExpression {
+  return {
+    filter: {
+      fieldName: 'hostName',
+      inListFilter: {
+        values: [...PRODUCTION_ANALYTICS_HOSTS],
+        caseSensitive: false,
+      },
+    },
+  }
+}
+
+export function buildCleanProductionFilter(
+  additionalExpressions: GA4FilterExpression[] = []
+): GA4FilterExpression {
+  return {
+    andGroup: {
+      expressions: [
+        buildProductionHostFilter(),
+        {
+          notExpression: {
+            orGroup: {
+              expressions: BREVO_SCANNER_SOURCE_MEDIUMS.map(value => ({
+                filter: {
+                  fieldName: 'sessionSourceMedium',
+                  stringFilter: {
+                    matchType: 'EXACT',
+                    value,
+                    caseSensitive: false,
+                  },
+                },
+              })),
+            },
+          },
+        },
+        ...additionalExpressions,
+      ],
+    },
+  }
+}

--- a/supabase/functions/funnel-report-cron/index.ts
+++ b/supabase/functions/funnel-report-cron/index.ts
@@ -1,5 +1,9 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import {
+  buildCleanProductionFilter,
+  buildProductionHostFilter,
+} from '../_shared/analytics-filters.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,6 +16,7 @@ const GA4_PROPERTY_ID = '496541587'
 // Funnel event names
 const FUNNEL_EVENTS = [
   'first_visit',
+  'email_landing_engaged',
   'trial_page_view',
   'trial_tool_selected',
   'trial_comps_search',
@@ -70,6 +75,13 @@ interface SourceMetrics {
   newUsers: number
   sessions: number
   engagementRate: number
+}
+
+interface TrafficSummary {
+  activeUsers: number
+  newUsers: number
+  sessions: number
+  engagedSessions: number
 }
 
 // Generate JWT for Google API authentication
@@ -274,6 +286,17 @@ function parseTrafficSources(response: GA4Response): SourceMetrics[] {
   return metrics
 }
 
+function parseTrafficSummary(response: GA4Response): TrafficSummary {
+  const values = response.rows?.[0]?.metricValues || []
+
+  return {
+    activeUsers: parseInt(values[0]?.value || '0', 10),
+    newUsers: parseInt(values[1]?.value || '0', 10),
+    sessions: parseInt(values[2]?.value || '0', 10),
+    engagedSessions: parseInt(values[3]?.value || '0', 10),
+  }
+}
+
 // Generate progress bar
 function progressBar(percentage: number): string {
   const filled = Math.round(percentage / 5)
@@ -292,6 +315,8 @@ function generateFunnelReport(
   pages: PageMetrics,
   landingPages: LandingPageMetrics[],
   sources: SourceMetrics[],
+  rawTraffic: TrafficSummary,
+  cleanTraffic: TrafficSummary,
   days: number
 ): { markdown: string; alerts: string[] } {
   const alerts: string[] = []
@@ -303,6 +328,7 @@ function generateFunnelReport(
   const searchCompleted = funnel['trial_search_completed'] || { eventCount: 0, totalUsers: 0 }
   const ctaClicked = funnel['trial_signup_cta_clicked'] || { eventCount: 0, totalUsers: 0 }
   const signupComplete = funnel['signup_completed'] || { eventCount: 0, totalUsers: 0 }
+  const emailLandingEngaged = funnel['email_landing_engaged'] || { eventCount: 0, totalUsers: 0 }
 
   // Tool breakdown
   const compsSearch = funnel['trial_comps_search'] || { eventCount: 0, totalUsers: 0 }
@@ -316,6 +342,8 @@ function generateFunnelReport(
   const ctaRate = searchCompleted.totalUsers > 0 ? (ctaClicked.totalUsers / searchCompleted.totalUsers) : 0
   const signupRate = ctaClicked.totalUsers > 0 ? (signupComplete.totalUsers / ctaClicked.totalUsers) : 0
   const overallRate = firstVisit.totalUsers > 0 ? (signupComplete.totalUsers / firstVisit.totalUsers) : 0
+  const excludedSessions = Math.max(rawTraffic.sessions - cleanTraffic.sessions, 0)
+  const excludedSessionRate = rawTraffic.sessions > 0 ? excludedSessions / rawTraffic.sessions : 0
 
   // Check for alerts
   if (overallRate < 0.01) {
@@ -326,6 +354,9 @@ function generateFunnelReport(
   }
   if (trialRate < 0.05) {
     alerts.push('Warning: First Visit to Trial rate <5%')
+  }
+  if (excludedSessionRate > 0.1) {
+    alerts.push(`Data quality: ${formatPct(excludedSessionRate)} of production-host sessions excluded as known scanner traffic`)
   }
 
   // Check landing page bounce rates
@@ -345,6 +376,27 @@ function generateFunnelReport(
   let markdown = `# KStoryBridge Signup Funnel Analysis
 
 **Period**: ${dateFormat(startDate)} - ${dateFormat(endDate)} (${days} days)
+
+---
+
+## Data Quality Guardrail
+
+| Metric | Raw production hosts | Clean external estimate | Excluded |
+|--------|---------------------:|------------------------:|---------:|
+| Sessions | ${rawTraffic.sessions} | ${cleanTraffic.sessions} | ${excludedSessions} (${formatPct(excludedSessionRate)}) |
+| Active Users | ${rawTraffic.activeUsers} | ${cleanTraffic.activeUsers} | ${Math.max(rawTraffic.activeUsers - cleanTraffic.activeUsers, 0)} |
+| New Users | ${rawTraffic.newUsers} | ${cleanTraffic.newUsers} | ${Math.max(rawTraffic.newUsers - cleanTraffic.newUsers, 0)} |
+| Engaged Sessions | ${rawTraffic.engagedSessions} | ${cleanTraffic.engagedSessions} | ${Math.max(rawTraffic.engagedSessions - cleanTraffic.engagedSessions, 0)} |
+
+The clean estimate includes only the three production hosts and excludes all observed Brevo/Sendinblue scanner referral domains. Legitimate email engagement is reconciled separately with Brevo campaign data.
+
+### Human email engagement
+
+| Signal | Users | Events |
+|--------|------:|-------:|
+| Trusted interaction after an email-attributed landing | ${emailLandingEngaged.totalUsers} | ${emailLandingEngaged.eventCount} |
+
+This is a conservative on-site signal: a tagged email landing must receive a trusted pointer, keyboard, or scroll interaction. A scanner page load alone does not count. Compare this total with Brevo's delivered and unique human-click totals; it is not a replacement for campaign-provider reporting.
 
 ---
 
@@ -490,13 +542,20 @@ serve(async (req) => {
     // Run all queries in parallel
     console.log('[funnel-report-cron] Fetching GA4 data...')
 
-    const [funnelResponse, pagesResponse, landingResponse, sourcesResponse] = await Promise.all([
+    const [
+      funnelResponse,
+      pagesResponse,
+      landingResponse,
+      sourcesResponse,
+      rawTrafficResponse,
+      cleanTrafficResponse,
+    ] = await Promise.all([
       // Query 1: Funnel events
       runGA4Report(accessToken, {
         dateRanges: [{ startDate, endDate }],
         dimensions: ['eventName'],
         metrics: ['eventCount', 'totalUsers'],
-        dimensionFilter: {
+        dimensionFilter: buildCleanProductionFilter([{
           filter: {
             fieldName: 'eventName',
             inListFilter: {
@@ -504,7 +563,7 @@ serve(async (req) => {
               caseSensitive: true,
             },
           },
-        },
+        }]),
         orderBys: [{ metric: { metricName: 'eventCount' }, desc: true }],
       }),
 
@@ -513,7 +572,7 @@ serve(async (req) => {
         dateRanges: [{ startDate, endDate }],
         dimensions: ['pagePath'],
         metrics: ['activeUsers', 'sessions', 'bounceRate', 'engagementRate'],
-        dimensionFilter: {
+        dimensionFilter: buildCleanProductionFilter([{
           filter: {
             fieldName: 'pagePath',
             inListFilter: {
@@ -521,7 +580,7 @@ serve(async (req) => {
               caseSensitive: false,
             },
           },
-        },
+        }]),
         orderBys: [{ metric: { metricName: 'sessions' }, desc: true }],
       }),
 
@@ -530,6 +589,7 @@ serve(async (req) => {
         dateRanges: [{ startDate, endDate }],
         dimensions: ['landingPage'],
         metrics: ['sessions', 'newUsers', 'engagementRate', 'bounceRate'],
+        dimensionFilter: buildCleanProductionFilter(),
         orderBys: [{ metric: { metricName: 'sessions' }, desc: true }],
         limit: 15,
       }),
@@ -539,8 +599,25 @@ serve(async (req) => {
         dateRanges: [{ startDate, endDate }],
         dimensions: ['sessionSourceMedium'],
         metrics: ['newUsers', 'sessions', 'engagementRate'],
+        dimensionFilter: buildCleanProductionFilter(),
         orderBys: [{ metric: { metricName: 'newUsers' }, desc: true }],
         limit: 10,
+      }),
+
+      // Query 5: Raw traffic on production hosts, retained only for visibility
+      runGA4Report(accessToken, {
+        dateRanges: [{ startDate, endDate }],
+        dimensions: [],
+        metrics: ['activeUsers', 'newUsers', 'sessions', 'engagedSessions'],
+        dimensionFilter: buildProductionHostFilter(),
+      }),
+
+      // Query 6: Clean production traffic used by customer KPIs
+      runGA4Report(accessToken, {
+        dateRanges: [{ startDate, endDate }],
+        dimensions: [],
+        metrics: ['activeUsers', 'newUsers', 'sessions', 'engagedSessions'],
+        dimensionFilter: buildCleanProductionFilter(),
       }),
     ])
 
@@ -551,6 +628,8 @@ serve(async (req) => {
     const pageMetrics = parsePagePerformance(pagesResponse)
     const landingPages = parseLandingPages(landingResponse)
     const trafficSources = parseTrafficSources(sourcesResponse)
+    const rawTraffic = parseTrafficSummary(rawTrafficResponse)
+    const cleanTraffic = parseTrafficSummary(cleanTrafficResponse)
 
     // Generate report
     console.log('[funnel-report-cron] Generating funnel report...')
@@ -559,6 +638,8 @@ serve(async (req) => {
       pageMetrics,
       landingPages,
       trafficSources,
+      rawTraffic,
+      cleanTraffic,
       days
     )
 


### PR DESCRIPTION
## Outcome

Establishes reliable GA4 measurement across the KStoryBridge website, buyer dashboard, creator app, and automated funnel reporting.

## Scope

- suppresses analytics for localhost, previews, staging, and authenticated internal admins by default
- supports an explicit analytics_debug=1 runtime override for controlled validation
- removes recipient identifiers and arbitrary URL parameters from email engagement events
- normalizes creator platform analytics, including the Lezhin mapping
- centralizes production-host and scanner-traffic filters for automated reporting
- adds admin internal-traffic metadata tooling and scheduled progress-report tooling
- documents the execution plan, acceptance criteria, operational ownership, and verified staging evidence

This PR contains five focused analytics commits cherry-picked from v2. It intentionally excludes the unrelated buyer-activation feature and database migration currently present on v2.

## Affected systems

- apps/dashboard
- apps/creator
- apps/website
- supabase/functions/funnel-report-cron
- shared analytics scripts and tests
- analytics reliability documentation

No database migrations are included.

## Verification

- dashboard build: pass
- creator build: pass
- website build: pass
- dashboard tests: 27 passed
- creator tests: 7 passed
- website tests: 10 passed
- shared script/function tests: 6 passed
- staging runtime: dashboard and creator suppress analytics by default and emit only with analytics_debug=1
- website preview runtime: default suppression verified; sanitized email_landing_engaged event verified with the debug override
- funnel-report-cron: already deployed and manually delivered successfully to three admins and Slack

The full monorepo build currently fails in the existing Storybook package at packages/storybook/.storybook/main.ts because __dirname is unavailable in its ESM context. The three affected application builds pass independently; this PR does not modify Storybook.

## Before merge

- review CI and focused diff
- configure/verify the GA4 production internal-traffic data filter manually
- confirm production release window

## Post-merge verification

- verify production website, dashboard, and creator analytics suppression/emission behavior
- verify the GitHub scheduled progress check is active from main
- monitor the next weekly Supabase funnel report

## Rollback

Revert this PR.

## Release sequencing after later v2 work

Later analytics work on `v2` is intentionally excluded from this foundation PR. The shared privacy sink depends on the canonical client contract, the weekly scorecard depends on later reporting helpers, and the authoritative server work includes approval-gated migrations. Do not cherry-pick those leaf commits into this branch.

Follow the four-wave entry, acceptance, and rollback gates in [ANALYTICS_PRODUCTION_RELEASE_SEQUENCE.md](https://github.com/creepyblues/kstorybridge-integrated/blob/v2/docs/active/ANALYTICS_PRODUCTION_RELEASE_SEQUENCE.md). The scheduled progress audit now fails closed if this PR gains a path outside its fixed migration-free Wave 1 allowlist.
